### PR TITLE
회원 / 상품 / 카테고리 table에 대한 Create  & Read 작업

### DIFF
--- a/src/main/java/com/shoptest/catmart/admin/service/CategoryService.java
+++ b/src/main/java/com/shoptest/catmart/admin/service/CategoryService.java
@@ -17,4 +17,8 @@ public interface CategoryService {
   /* front main page 카테고리 select */
   List<FrontCategoryDto> selectFrontCategoryList();
 
+  /* 카테고리 정보 detail select */
+  FrontCategoryDto selectFrontCategoryDetail(long categoryId);
+
+
 }

--- a/src/main/java/com/shoptest/catmart/admin/service/impl/CategoryServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/admin/service/impl/CategoryServiceImpl.java
@@ -10,6 +10,7 @@ import com.shoptest.catmart.admin.service.CategoryImgService;
 import com.shoptest.catmart.admin.service.CategoryService;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,5 +52,22 @@ public class CategoryServiceImpl implements CategoryService {
   @Override
   public List<FrontCategoryDto> selectFrontCategoryList() {
     return categoryMapper.frontCategoryList();
+  }
+
+  @Override
+  public FrontCategoryDto selectFrontCategoryDetail(long categoryId) {
+
+    Optional<Category> optionalCategory = categoryRepository.findById(categoryId);
+    if (optionalCategory.isPresent()) {
+
+      Category category = optionalCategory.get();
+
+      FrontCategoryDto detailDto = new FrontCategoryDto();
+      detailDto.setCategoryId(category.getCategoryId());
+      detailDto.setCategoryName(category.getCategoryName());
+      return detailDto;
+    }
+
+    return null;
   }
 }

--- a/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
+++ b/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
@@ -1,0 +1,27 @@
+package com.shoptest.catmart.product.controller;
+
+import com.shoptest.catmart.product.dto.FrontProductDto;
+import com.shoptest.catmart.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/product")
+@RequiredArgsConstructor
+public class FrontProductController {
+
+  private final ProductService productService;
+
+  @GetMapping("/list")
+  public String frontProductList(Model model, FrontProductDto parameter) {
+
+    model.addAttribute("frontProductList", productService.selectFrontProductList(parameter));
+
+    return "/product/front_product_list";
+  }
+
+
+}

--- a/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
+++ b/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
@@ -1,5 +1,7 @@
 package com.shoptest.catmart.product.controller;
 
+import com.shoptest.catmart.admin.dto.FrontCategoryDto;
+import com.shoptest.catmart.admin.service.CategoryService;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +16,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class FrontProductController {
 
   private final ProductService productService;
+  private final CategoryService categoryService;
 
   @GetMapping("/list")
   public String frontProductList(Model model, FrontProductDto parameter) {
 
+    FrontCategoryDto selectCategory = null;
+    if (parameter.getCategoryId() != null) {
+      selectCategory = categoryService.selectFrontCategoryDetail(parameter.getCategoryId());
+    }
+
+    model.addAttribute("selectCategory", selectCategory);
     model.addAttribute("frontProductList", productService.selectFrontProductList(parameter));
+    model.addAttribute("categoryList", categoryService.categorySelectionList());
 
     return "/product/front_product_list";
   }

--- a/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
+++ b/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
@@ -2,12 +2,14 @@ package com.shoptest.catmart.product.controller;
 
 import com.shoptest.catmart.admin.dto.FrontCategoryDto;
 import com.shoptest.catmart.admin.service.CategoryService;
+import com.shoptest.catmart.product.dto.FrontProductDetailDto;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -31,6 +33,18 @@ public class FrontProductController {
     model.addAttribute("categoryList", categoryService.categorySelectionList());
 
     return "/product/front_product_list";
+  }
+
+  @GetMapping("/detail/{productItemId}")
+  public String frontProductDetail(Model model, @PathVariable("productItemId") Long productItemId) {
+
+    FrontProductDetailDto detail = new FrontProductDetailDto();
+    if (productItemId != null) {
+      detail = productService.selectFrontProductDetail(productItemId);
+    }
+
+    model.addAttribute("detail", detail);
+    return "/product/front_product_detail";
   }
 
 

--- a/src/main/java/com/shoptest/catmart/product/dto/FrontProductDetailDto.java
+++ b/src/main/java/com/shoptest/catmart/product/dto/FrontProductDetailDto.java
@@ -6,16 +6,19 @@ import lombok.Setter;
 import lombok.ToString;
 
 /**
- * FRONT 조회용 상품 목록 dto
+ * FRONT 조회용 상품 상세 dto
  * */
 
 @Getter
 @Setter
 @ToString
-public class FrontProductDto {
+public class FrontProductDetailDto {
 
   /* 상품 카테고리 ID */
   private Long categoryId;
+
+  /* 상품 카테고리명 */
+  private String categoryName;
 
   /* 상품 ID */
   private Long productItemId;

--- a/src/main/java/com/shoptest/catmart/product/dto/FrontProductDto.java
+++ b/src/main/java/com/shoptest/catmart/product/dto/FrontProductDto.java
@@ -1,0 +1,38 @@
+package com.shoptest.catmart.product.dto;
+
+import com.shoptest.catmart.product.type.ItemStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * FRONT 조회용 상품 dto
+ * */
+
+@Getter
+@Setter
+@ToString
+public class FrontProductDto {
+
+  /* 상품 카테고리 ID */
+  private Long categoryId;
+
+  /* 상품이름 */
+  private String itemName;
+
+  /* 상품가격 */
+  private int price;
+
+  /* 상품 상태 - (판매중, 품절) */
+  private ItemStatus itemStatus;
+
+  /* 상품내용 */
+  private String itemSubject;
+
+  /* 상품 게시 여부 */
+  private boolean postYn;
+
+  /* 이미지 url 경로 */
+  private String urlImgPath;
+
+}

--- a/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
+++ b/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.product.mapper;
 
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDetailDto;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -17,5 +18,8 @@ public interface ProductMapper {
 
   /* front - 상품 목록 조회 */
   List<FrontProductDto> frontProductList(FrontProductDto parameter);
+
+  /* front - 상품 상세 조회 */
+  FrontProductDetailDto frontProductDetail(long productItemId);
 
 }

--- a/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
+++ b/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.product.mapper;
 
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDto;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -13,5 +14,8 @@ public interface ProductMapper {
 
   /* 관리자 - 상품 상세 조회 */
   AdminProductMngDetailDto adminProductMngDetail(long productItemId);
+
+  /* front - 상품 목록 조회 */
+  List<FrontProductDto> frontProductList(FrontProductDto parameter);
 
 }

--- a/src/main/java/com/shoptest/catmart/product/service/ProductService.java
+++ b/src/main/java/com/shoptest/catmart/product/service/ProductService.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.product.service;
 
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDetailDto;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.dto.ProductItemDto;
 import java.util.List;
@@ -20,5 +21,8 @@ public interface ProductService {
 
   /* front - 상품목록 조회 */
   List<FrontProductDto> selectFrontProductList(FrontProductDto parameter);
+
+  /* front - 상품상세 조회 */
+  FrontProductDetailDto selectFrontProductDetail(Long productItemId);
 
 }

--- a/src/main/java/com/shoptest/catmart/product/service/ProductService.java
+++ b/src/main/java/com/shoptest/catmart/product/service/ProductService.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.product.service;
 
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.dto.ProductItemDto;
 import java.util.List;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,5 +17,8 @@ public interface ProductService {
 
   /* 관리자 - 상품상세 조회 */
   AdminProductMngDetailDto selectAdminProductMngDetail(long productItemId);
+
+  /* front - 상품목록 조회 */
+  List<FrontProductDto> selectFrontProductList(FrontProductDto parameter);
 
 }

--- a/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package com.shoptest.catmart.product.service.impl;
 import com.shoptest.catmart.product.domain.ProductItem;
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.dto.ProductItemDto;
 import com.shoptest.catmart.product.mapper.ProductMapper;
 import com.shoptest.catmart.product.repository.ProductItemRepository;
@@ -55,5 +56,10 @@ public class ProductServiceImpl implements ProductService {
   @Override
   public AdminProductMngDetailDto selectAdminProductMngDetail(long productItemId) {
     return productMapper.adminProductMngDetail(productItemId);
+  }
+
+  @Override
+  public List<FrontProductDto> selectFrontProductList(FrontProductDto parameter) {
+    return productMapper.frontProductList(parameter);
   }
 }

--- a/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
@@ -3,6 +3,7 @@ package com.shoptest.catmart.product.service.impl;
 import com.shoptest.catmart.product.domain.ProductItem;
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
+import com.shoptest.catmart.product.dto.FrontProductDetailDto;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.dto.ProductItemDto;
 import com.shoptest.catmart.product.mapper.ProductMapper;
@@ -61,5 +62,10 @@ public class ProductServiceImpl implements ProductService {
   @Override
   public List<FrontProductDto> selectFrontProductList(FrontProductDto parameter) {
     return productMapper.frontProductList(parameter);
+  }
+
+  @Override
+  public FrontProductDetailDto selectFrontProductDetail(Long productItemId) {
+    return productMapper.frontProductDetail(productItemId);
   }
 }

--- a/src/main/resources/mybatis/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/product/ProductMapper.xml
@@ -55,4 +55,21 @@
     </if>
   </select>
 
+  <select id="frontProductDetail" resultType="com.shoptest.catmart.product.dto.FrontProductDetailDto">
+    SELECT
+      A.PRODUCT_ITEM_ID
+      , A.ITEM_NAME
+      , A.ITEM_STATUS
+      , A.ITEM_SUBJECT
+      , A.PRICE
+      , B.URL_IMG_PATH
+      , (SELECT C.CATEGORY_NAME FROM CATEGORY C WHERE C.CATEGORY_ID = A.CATEGORY_ID) AS CATEGORY_NAME
+      , A.CATEGORY_ID
+    FROM PRODUCT_ITEM A
+    INNER JOIN ITEM_IMG B
+    ON A.PRODUCT_ITEM_ID = B.PRODUCT_ITEM_ID
+    WHERE A.POST_YN = 1
+    AND A.PRODUCT_ITEM_ID = #{productItemId}
+  </select>
+
 </mapper>

--- a/src/main/resources/mybatis/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/product/ProductMapper.xml
@@ -18,7 +18,6 @@
     ON A.PRODUCT_ITEM_ID = B.PRODUCT_ITEM_ID
   </select>
 
-
   <select id="adminProductMngDetail" resultType="com.shoptest.catmart.product.dto.AdminProductMngDetailDto">
     SELECT
       A.PRODUCT_ITEM_ID
@@ -36,6 +35,24 @@
     INNER JOIN ITEM_IMG B
     ON A.PRODUCT_ITEM_ID = B.PRODUCT_ITEM_ID
     WHERE A.PRODUCT_ITEM_ID = #{productItemId}
+  </select>
+
+  <select id="frontProductList"
+    parameterType="com.shoptest.catmart.product.dto.FrontProductDto"
+    resultType="com.shoptest.catmart.product.dto.FrontProductDto">
+    SELECT
+      A.PRODUCT_ITEM_ID
+      , A.ITEM_NAME
+      , A.PRICE
+      , A.ITEM_STATUS
+      , B.URL_IMG_PATH
+    FROM PRODUCT_ITEM A
+    INNER join ITEM_IMG B
+    on A.PRODUCT_ITEM_ID = B.PRODUCT_ITEM_ID
+    WHERE A.POST_YN = 1
+    <if test="categoryId != null and !''.equals(categoryId)">
+      AND A.CATEGORY_ID = #{categoryId}
+    </if>
   </select>
 
 </mapper>

--- a/src/main/resources/templates/admin/product/admin_product_detail.html
+++ b/src/main/resources/templates/admin/product/admin_product_detail.html
@@ -79,50 +79,53 @@
   <div class="content">
     <h2>상품 상세관리</h2>
 
-    <div id="productCard" class="card mb-3" style="max-width: 1100px;">
-      <div class="row no-gutters">
+    <div class="d-flex justify-content-center">
+      <div id="productCard" class="card mb-3" style="max-width: 1100px;">
+        <div class="row no-gutters">
 
-        <div class="col-md-7">
-          <img th:src="${detail.urlImgPath}" class="card-img" alt="...">
-        </div>
-
-        <div class="col-md-5">
-
-          <div class="card-body">
-
-            <h2 class="card-title" th:text="${detail.itemName}">
-            </h2>
-            <hr/>
-            <p class="card-text">
-              <h3><span class="badge badge-dark">상세설명</span></h3>
-              <h4><p th:text="${detail.itemSubject}"></p></h4>
-            </p>
-            <p class="card-text">
-              <h3><span class="badge badge-dark">판매가격</span></h3>
-              <h4><p th:text="${detail.price}"></p></h4>
-            </p>
-            <p class="card-text">
-              <h3><span class="badge badge-dark">게시 여부</span></h3>
-              <h4><p th:text="${detail.postYn}"></p></h4>
-            </p>
-            <p class="card-text">
-              <h3><span class="badge badge-dark">상품 재고</span></h3>
-              <h4><p th:text="${detail.stock}"></p></h4>
-            </p>
-            <p class="card-text">
-              <h3><span class="badge badge-dark">상품 카테고리</span></h3>
-              <h4><p th:text="${detail.categoryName}"></p></h4>
-            </p>
-
-            <p class="card-text">
-              <small class="text-muted">Last updated 3 mins ago</small>
-            </p>
+          <div class="col-md-5">
+            <img th:src="${detail.urlImgPath}" class="card-img" alt="...">
           </div>
+
+          <div class="col-md-7">
+
+            <div class="card-body">
+
+              <h2 class="card-title" th:text="${detail.itemName}">
+              </h2>
+              <hr/>
+              <p class="card-text">
+                <h3><span class="badge badge-dark">상세설명</span></h3>
+                <h4><p th:text="${detail.itemSubject}"></p></h4>
+              </p>
+              <p class="card-text">
+                <h3><span class="badge badge-dark">판매가격</span></h3>
+                <h4><p th:text="${detail.price}"></p></h4>
+              </p>
+              <p class="card-text">
+                <h3><span class="badge badge-dark">게시 여부</span></h3>
+                <h4><p th:text="${detail.postYn}"></p></h4>
+              </p>
+              <p class="card-text">
+                <h3><span class="badge badge-dark">상품 재고</span></h3>
+                <h4><p th:text="${detail.stock}"></p></h4>
+              </p>
+              <p class="card-text">
+                <h3><span class="badge badge-dark">상품 카테고리</span></h3>
+                <h4><p th:text="${detail.categoryName}"></p></h4>
+              </p>
+
+              <p class="card-text">
+                <small class="text-muted">Last updated 3 mins ago</small>
+              </p>
+            </div>
+          </div>
+
         </div>
 
       </div>
-
     </div>
+
 
 
   </div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -17,8 +17,9 @@
         <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
           <div class="navbar-nav">
             <a class="nav-link active" aria-current="page" href="/main">Main</a>
-            <a class="nav-link" href="#">Features</a>
-            <a class="nav-link" href="#">Pricing</a>
+            <a class="nav-link" href="/product/list">전체 상품</a>
+            <a sec:authorize="isAuthenticated()" class="nav-link" href="#">내 주문내역</a>
+            <a sec:authorize="isAuthenticated()" class="nav-link" href="#">장바구니</a>
             <a sec:authorize="hasAnyAuthority('ROLE_ADMIN_SELLER')" class="nav-link" href="/admin/product/list.do">상품 관리</a>
             <a sec:authorize="hasAnyAuthority('ROLE_ADMIN_SELLER')" class="nav-link" href="/admin/category/add.do">카테고리 관리</a>
             <a sec:authorize="isAnonymous()" class="nav-link" href="/member/login">로그인</a>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -102,18 +102,42 @@
     </nav>
 
     <!-- 카테고리 출력 -->
-    <ul class="list-group list-group-horizontal d-flex justify-content-center">
-      <li class="list-group-item" th:each="category : ${frontCategoryList}">
-        <div class="card" style="width: 13rem;">
+    <!--
+    <ul class="list-group list-group-horizontal">
+      <div th:each="category, i : ${frontCategoryList}" class="d-flex justify-content-center">
+        <li class="list-group-item">
+          <div class="card" style="width: 13rem;">
+            <img th:src="${category.urlImgPath}" class="card-img-top" alt="...">
+            <div class="card-body">
+              <a th:href="'/product/list?categoryId=' + ${category.categoryId}"
+                 th:text="${category.categoryName}"
+                 class="card-text badge badge-pill badge-light"></a>
+            </div>
+          </div>
+        </li>
+        <hr th:if="${i.index % 3 == 0}" style="visibility: hidden; height: 40px;" />
+      </div>
+    </ul>
+    -->
+
+    <div class="card-deck d-flex justify-content-center">
+      <div th:each="category, i : ${frontCategoryList}">
+
+        <div class="card border-0" style="width: 175px;">
           <img th:src="${category.urlImgPath}" class="card-img-top" alt="...">
           <div class="card-body">
-            <a th:href="'/product/list?categoryId=' + ${category.categoryId}"
-               th:text="${category.categoryName}"
-               class="card-text badge badge-pill badge-light"></a>
+            <h5 class="card-title">
+              <a th:href="'/product/list?categoryId=' + ${category.categoryId}"
+                 th:text="${category.categoryName}"></a>
+            </h5>
           </div>
         </div>
-      </li>
-    </ul>
+
+        <hr th:if="${i.index % 5 == 0}" style="visibility: hidden; height: 40px;" />
+
+      </div>
+    </div>
+
 
   </div>
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -107,7 +107,9 @@
         <div class="card" style="width: 13rem;">
           <img th:src="${category.urlImgPath}" class="card-img-top" alt="...">
           <div class="card-body">
-            <p th:text="${category.categoryName}" class="card-text"></p>
+            <a th:href="'/product/list?categoryId=' + ${category.categoryId}"
+               th:text="${category.categoryName}"
+               class="card-text badge badge-pill badge-light"></a>
           </div>
         </div>
       </li>

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -44,8 +44,8 @@
       .content {
         margin-bottom: 100px;
         margin-top: 50px;
-        margin-left: 200px;
-        margin-right: 200px;
+        margin-left: 150px;
+        margin-right: 150px;
       }
 
 

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -48,11 +48,6 @@
         margin-right: 200px;
       }
 
-      .front-banner {
-        margin-left: 100px;
-        margin-right: 100px;
-        margin-bottom: 60px;
-      }
 
     </style>
   </th:block>
@@ -64,45 +59,20 @@
 
   <div class="content">
 
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page">
-          카테고리 > <span th:if="${selectCategory}" th:text="${selectCategory.categoryName}"></span><span th:if="${selectCategory == null}">전체</span>
-        </li>
-      </ol>
-    </nav>
-
-    <!-- search category bar -->
-    <div class="row justify-content-md-center" style="margin-bottom: 40px;">
-      <div th:each="category : ${categoryList}" class="col-md-auto">
-        <h5>
-          <a th:href="'list?categoryId=' + ${category.categoryId}" th:text="${category.categoryName}"
-             class="badge badge-pill badge-light"></a>
-        </h5>
-      </div>
-    </div>
-
-    <!-- product list -->
-    <div class="card-deck d-flex justify-content-center">
-      <div th:each="product, i : ${frontProductList}">
-
-        <div class="card" style="width: 300px;">
-          <img th:src="${product.urlImgPath}" class="card-img-top" alt="...">
+    <div class="card mb-3" style="max-width: 540px;">
+      <div class="row no-gutters">
+        <div class="col-md-4">
+          <img src="..." class="card-img" alt="...">
+        </div>
+        <div class="col-md-8">
           <div class="card-body">
-            <h5 class="card-title">
-              <a th:href="'detail/' + ${product.productItemId}"
-                 th:text="${product.itemName}"></a>
-            </h5>
-            <p class="card-text" th:text="${product.price}"></p>
+            <h5 class="card-title">Card title</h5>
+            <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
             <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
           </div>
         </div>
-
-        <hr th:if="${i.index % 3 == 0}" style="visibility: hidden; height: 40px;" />
-
       </div>
     </div>
-
 
 
 

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -59,21 +59,59 @@
 
   <div class="content">
 
-    <div class="card mb-3" style="max-width: 540px;">
-      <div class="row no-gutters">
-        <div class="col-md-4">
-          <img src="..." class="card-img" alt="...">
-        </div>
-        <div class="col-md-8">
-          <div class="card-body">
-            <h5 class="card-title">Card title</h5>
-            <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-            <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+    <!-- category info bar -->
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">
+          카테고리 > <a th:href="'/product/list?categoryId=' + ${detail.categoryId}" th:text="${detail.categoryName}"></a> > <span th:text="${detail.itemName}"></span>
+        </li>
+      </ol>
+    </nav>
+
+    <!-- product detail area -->
+    <div class="d-flex justify-content-center">
+      <div class="card mb-3" style="max-width: 1200px;">
+        <div class="row no-gutters">
+          <div class="col-md-6">
+            <img th:src="${detail.urlImgPath}" class="card-img" alt="...">
+          </div>
+          <div class="col-md-6">
+            <div class="card-body">
+              <h2 th:text="${detail.itemName}" class="card-title"></h2>
+              <hr style="visibility: hidden; margin-bottom: 13px;"/>
+              <p class="card-text">
+                <div class="d-flex flex-row-reverse bd-highlight">
+                  <h3><span th:text="${detail.price}" class="badge badge-warning"></span>원</h3>
+                </div>
+              </p>
+              <hr/>
+              <p class="card-text" style="height: 110px;">
+                <span th:text="${detail.itemSubject}"></span>
+              </p>
+              <hr/>
+              <p class="card-text">
+                <div class="container">
+                  <p>
+                    <span>수량</span><span><input type="number" style="width:80px; margin-left: 13px;" /></span>
+                  </p>
+                  <p>
+                    <span>결제 금액</span>
+                    <h2><span>10,000원</span></h2>
+                  </p>
+                </div>
+              </p>
+              <hr/>
+              <p class="card-text">
+                <button class="btn btn-light btn-lg btn-block" type="submit">장바구니 담기</button>
+              </p>
+              <p class="card-text">
+                <button class="btn btn-primary btn-lg btn-block" type="submit">바로 주문하기</button>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
-
 
 
 

--- a/src/main/resources/templates/product/front_product_list.html
+++ b/src/main/resources/templates/product/front_product_list.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+  <th:block layout:fragment="script"></th:block>
+  <th:block layout:fragment="css">
+    <style>
+
+      html {
+        position: relative;
+        min-height: 100%;
+        margin: 0;
+      }
+
+      body {
+        min-height: 100%;
+      }
+
+      .footer {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        padding: 15px 0;
+        text-align: center;
+      }
+
+      .header {
+        margin-bottom: 20px;
+
+      }
+
+      .content {
+        margin-bottom: 100px;
+        margin-top: 50px;
+        margin-left: 200px;
+        margin-right: 200px;
+      }
+
+      .front-banner {
+        margin-left: 100px;
+        margin-right: 100px;
+        margin-bottom: 60px;
+      }
+
+    </style>
+  </th:block>
+
+</head>
+<body>
+
+  <div th:replace="fragments/header::header"></div>
+
+  <div class="content">
+
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">카테고리 > 음식</li>
+      </ol>
+    </nav>
+
+    <div class="card-deck d-flex justify-content-center">
+      <div th:each="product, i : ${frontProductList}">
+
+        <div class="card" style="width: 300px;">
+          <img th:src="${product.urlImgPath}" class="card-img-top" alt="...">
+          <div class="card-body">
+            <h5 class="card-title">
+              <span th:text="${product.itemName}"></span>
+            </h5>
+            <p class="card-text" th:text="${product.price}"></p>
+            <p class="card-text"><small class="text-muted">Last updated 3 mins ago</small></p>
+          </div>
+        </div>
+
+        <hr th:if="${i.index % 3 == 0}" style="visibility: hidden; height: 40px;" />
+
+      </div>
+    </div>
+
+
+
+
+
+
+  </div>
+
+  <div th:replace="fragments/footer::footer"></div>
+
+</body>
+</html>

--- a/src/main/resources/templates/product/front_product_list.html
+++ b/src/main/resources/templates/product/front_product_list.html
@@ -75,7 +75,7 @@
     <!-- search category bar -->
     <div class="row justify-content-md-center" style="margin-bottom: 40px;">
       <div th:each="category : ${categoryList}" class="col-md-auto">
-        <h5>
+        <h5> #
           <a th:href="'list?categoryId=' + ${category.categoryId}" th:text="${category.categoryName}"
              class="badge badge-pill badge-light"></a>
         </h5>

--- a/src/main/resources/templates/product/front_product_list.html
+++ b/src/main/resources/templates/product/front_product_list.html
@@ -86,7 +86,7 @@
     <div class="card-deck d-flex justify-content-center">
       <div th:each="product, i : ${frontProductList}">
 
-        <div class="card" style="width: 300px;">
+        <div class="card rounded" style="width: 300px;">
           <img th:src="${product.urlImgPath}" class="card-img-top" alt="...">
           <div class="card-body">
             <h5 class="card-title">

--- a/src/main/resources/templates/product/front_product_list.html
+++ b/src/main/resources/templates/product/front_product_list.html
@@ -66,10 +66,23 @@
 
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
-        <li class="breadcrumb-item active" aria-current="page">카테고리 > 음식</li>
+        <li class="breadcrumb-item active" aria-current="page">
+          카테고리 > <span th:if="${selectCategory}" th:text="${selectCategory.categoryName}"></span><span th:if="${selectCategory == null}">전체</span>
+        </li>
       </ol>
     </nav>
 
+    <!-- search bar -->
+    <div class="row justify-content-md-center" style="margin-bottom: 40px;">
+      <div th:each="category : ${categoryList}" class="col-md-auto">
+        <h5>
+          <a th:href="'list?categoryId=' + ${category.categoryId}" th:text="${category.categoryName}"
+             class="badge badge-pill badge-light"></a>
+        </h5>
+      </div>
+    </div>
+
+    <!-- product list -->
     <div class="card-deck d-flex justify-content-center">
       <div th:each="product, i : ${frontProductList}">
 


### PR DESCRIPTION
:white_check_mark: Changes

- 상품 카테고리에 따른 상품 목록 조회(고객 - FO) / 상품 상세 페이지(고객 - FO) 를 퍼블리싱하고
 구현된 기능인 카테고리 등록 & 상품 등록(관리자페이지 - BO)을 통해 기초 data를 넣어서 출력 확인하였습니다.

<br>

:heavy_plus_sign: Related Details

- 정렬 / 페이징 / 검색 기능은 이번 프로젝트 도메인의 핵심 기능인  장바구니 담기 / 주문 구현 테스트 이후, 하기로.. 주차 계획을 수정하였습니다. 
- 현재까지 구현한 기능은 table 기준으로
![check_table](https://user-images.githubusercontent.com/65488155/210511668-12ea7612-e7e0-4795-b355-456b1a5fd199.jpg)

Member / Product / Category / IMG에 대한 Create & Read 입니다.
- 일정에 맞추느라 validation 부분은 생략하고 진행했는데, 장바구니 기능(CART table)을 구현하면서 이 부분을 보완할 계획입니다.
- 상품 등록 / 회원 가입 부분 validation 추가해야 합니다.


<br>

:pray: To Reviewers
- 기획 시 구상한 일정에 맞추느라 우선 기초 data에 대한 기능은 지금까지의 커밋본으로 정리 후, 장바구니 담기 및 주문 진행을 하기로 하였습니다. 