### PR TITLE
Pr w04 02

### DIFF
--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -1,6 +1,7 @@
 package com.shoptest.catmart.cart.controller;
 
 import com.shoptest.catmart.cart.dto.CartItemAddInputDto;
+import com.shoptest.catmart.cart.dto.CartItemDeleteInputDto;
 import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import com.shoptest.catmart.cart.service.CartService;
 import com.shoptest.catmart.common.model.ResponseResult;
@@ -9,9 +10,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -51,6 +56,25 @@ public class ApiCartController {
     Long updatedCartItemId = cartService.updateItemQuantityInCart(email, parameter);
 
     if (updatedCartItemId == null) {
+      ResponseResult responseResult = new ResponseResult(false);
+      return ResponseEntity.ok().body(responseResult);
+    }
+
+    ResponseResult responseResult = new ResponseResult(true);
+    return ResponseEntity.ok().body(responseResult);
+  }
+
+  //장바구니 내역 조회 - 장바구니 상품 삭제
+  @DeleteMapping("/api/cart/delete-product-req")
+  public ResponseEntity<?> cartProductDelete(
+      Model model
+      , @RequestBody CartItemDeleteInputDto parameter
+      , Principal principal) {
+
+    String email = principal.getName();
+
+    Long deletedCartItemId = cartService.deleteItemInCart(email, parameter);
+    if (deletedCartItemId == null) {
       ResponseResult responseResult = new ResponseResult(false);
       return ResponseEntity.ok().body(responseResult);
     }

--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -1,18 +1,22 @@
 package com.shoptest.catmart.cart.controller;
 
 import com.shoptest.catmart.cart.dto.CartItemAddInputDto;
+import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import com.shoptest.catmart.cart.service.CartService;
 import com.shoptest.catmart.common.model.ResponseResult;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class ApiCartController {
 
   private final CartService cartService;
@@ -28,6 +32,25 @@ public class ApiCartController {
     Long savedCartItemId = cartService.addItemInCart(email, parameter);
 
     if (savedCartItemId == null) {
+      ResponseResult responseResult = new ResponseResult(false);
+      return ResponseEntity.ok().body(responseResult);
+    }
+
+    ResponseResult responseResult = new ResponseResult(true);
+    return ResponseEntity.ok().body(responseResult);
+  }
+
+  //장바구니 내역 조회 - 장바구니 상품 수량 변경
+  @PutMapping("/api/cart/update-quantity-req")
+  public ResponseEntity<?> cartProductQuantityUpdate(
+      Model model
+      , @RequestBody CartItemUpdateInputDto parameter
+      , Principal principal) {
+
+    String email = principal.getName();
+    Long updatedCartItemId = cartService.updateItemQuantityInCart(email, parameter);
+
+    if (updatedCartItemId == null) {
       ResponseResult responseResult = new ResponseResult(false);
       return ResponseEntity.ok().body(responseResult);
     }

--- a/src/main/java/com/shoptest/catmart/cart/dto/CartItemDeleteInputDto.java
+++ b/src/main/java/com/shoptest/catmart/cart/dto/CartItemDeleteInputDto.java
@@ -1,0 +1,16 @@
+package com.shoptest.catmart.cart.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * front 장바구니 내역 - 장바구니 상품수량 delete DTO
+ * */
+@Getter
+@Setter
+public class CartItemDeleteInputDto {
+
+  /* 상품 Id */
+  private Long cartItemId;
+
+}

--- a/src/main/java/com/shoptest/catmart/cart/dto/CartItemUpdateInputDto.java
+++ b/src/main/java/com/shoptest/catmart/cart/dto/CartItemUpdateInputDto.java
@@ -1,0 +1,19 @@
+package com.shoptest.catmart.cart.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * front 장바구니 내역 - 장바구니 상품수량 update DTO
+ * */
+@Getter
+@Setter
+public class CartItemUpdateInputDto {
+
+  /* 상품 Id */
+  private Long cartItemId;
+
+  /* 장바구니_상품 개수 */
+  private int quantity;
+
+}

--- a/src/main/java/com/shoptest/catmart/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/shoptest/catmart/cart/repository/CartItemRepository.java
@@ -8,4 +8,6 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
   Optional<CartItem> findByCartCartIdAndProductItemProductItemId(Long cartId, Long productItemId);
 
+  Long deleteByCartCartIdAndCartItemId(Long cartId, Long cartItemId);
+
 }

--- a/src/main/java/com/shoptest/catmart/cart/service/CartService.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/CartService.java
@@ -1,7 +1,9 @@
 package com.shoptest.catmart.cart.service;
 
+import com.shoptest.catmart.cart.domain.CartItem;
 import com.shoptest.catmart.cart.dto.CartItemAddInputDto;
 import com.shoptest.catmart.cart.dto.CartItemDetailDto;
+import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import java.util.List;
 
 public interface CartService {
@@ -11,5 +13,8 @@ public interface CartService {
 
   /* 고객 - 장바구니 내역 목록 조회 */
   List<CartItemDetailDto> selectCartItemDetailList(String email);
+
+  /* 고객 - 장바구니 내역 목록 > 장바구니 상품 수량 변경 */
+  Long updateItemQuantityInCart(String email, CartItemUpdateInputDto parameter);
 
 }

--- a/src/main/java/com/shoptest/catmart/cart/service/CartService.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/CartService.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.cart.service;
 
 import com.shoptest.catmart.cart.domain.CartItem;
 import com.shoptest.catmart.cart.dto.CartItemAddInputDto;
+import com.shoptest.catmart.cart.dto.CartItemDeleteInputDto;
 import com.shoptest.catmart.cart.dto.CartItemDetailDto;
 import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import java.util.List;
@@ -16,5 +17,8 @@ public interface CartService {
 
   /* 고객 - 장바구니 내역 목록 > 장바구니 상품 수량 변경 */
   Long updateItemQuantityInCart(String email, CartItemUpdateInputDto parameter);
+
+  /* 고객 - 장바구니 내역 목록 > 장바구니 상품 삭제 */
+  Long deleteItemInCart(String email, CartItemDeleteInputDto parameter);
 
 }

--- a/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
@@ -3,6 +3,7 @@ package com.shoptest.catmart.cart.service.impl;
 import com.shoptest.catmart.cart.domain.Cart;
 import com.shoptest.catmart.cart.domain.CartItem;
 import com.shoptest.catmart.cart.dto.CartItemAddInputDto;
+import com.shoptest.catmart.cart.dto.CartItemDeleteInputDto;
 import com.shoptest.catmart.cart.dto.CartItemDetailDto;
 import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import com.shoptest.catmart.cart.mapper.CartMapper;
@@ -142,6 +143,31 @@ public class CartServiceImpl implements CartService {
     cartItemRepository.save(cartItem);
 
     return cartItem.getCartItemId();
+  }
+
+  @Transactional
+  @Override
+  public Long deleteItemInCart(String email, CartItemDeleteInputDto parameter) {
+
+    //member data check
+    Optional<Member> optionalMember = memberRepository.findByEmail(email);
+    if (!optionalMember.isPresent()) {
+      //exception.. member
+      return null;
+    }
+    Member member = optionalMember.get();
+
+    //cart data check
+    Optional<Cart> optionalCart = cartRepository.findByMemberMemberId(member.getMemberId());
+    if (!optionalCart.isPresent()) {
+      //exception.. cart
+      return null;
+    }
+    Cart cart = optionalCart.get();
+
+    //cartItem data delete
+    Long result = cartItemRepository.deleteByCartCartIdAndCartItemId(cart.getCartId(), parameter.getCartItemId());
+    return result;
   }
 
 

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -29,7 +29,7 @@
               let changeProductParam = {
                 cartItemId: this.parentNode.querySelector('input[type=hidden]').value
                 , quantity: this.value
-              }
+              };
 
               console.log('확인');
               console.log(changeProductParam);
@@ -71,6 +71,28 @@
         //전체 합계 금액 계산
         function calculateTotalPrice() {
           console.log('calculateTotalPrice coll 확인');
+
+          let totalPrice = 0;
+
+          document.querySelectorAll('.price').forEach(
+            function(item) {
+              console.log('item확인확인');
+              console.log(item);
+
+              let price = item.querySelector('span').innerHTML;
+              console.log('가격확인확인--->' + price);
+
+              let quantity = item.parentNode.parentNode.parentNode.querySelector('input[type=number]').value;
+              console.log('부모요소요소000>');
+              console.log(quantity);
+
+
+              totalPrice += price * quantity;
+            }
+          );
+
+          document.getElementById('totalPriceArea').innerHTML = totalPrice + '원';
+
         }
 
 
@@ -153,7 +175,7 @@
           </tr>
         </thead>
         <tbody>
-          <tr th:each="cartItem, i : ${cartItemList}">
+          <tr th:each="cartItem, i : ${cartItemList}" class="cart-item">
             <td class="col-4">
               <!-- img -->
               <div class="border-0 card mb-3" style="max-width: 300px;">
@@ -182,8 +204,10 @@
             </td>
             <td class="col-4">
               <!-- price -->
-              <div class="price">
-                <h2><span th:text="${cartItem.price}" class="badge badge-pill badge-light price"></span>원</h2>
+              <div>
+                <h2 class="price">
+                  <span th:text="${cartItem.price}" class="badge badge-pill badge-light"></span>원
+                </h2>
               </div>
             </td>
             <td class="col-2">
@@ -209,7 +233,7 @@
             배송비 (금액 30,000원 이상 무료) <br/> + <span>3000</span> 원 <br/>
           </div>
           <div class="col-3">
-            <h3>결제 금액 <span>23000원</span></h3>
+            <h3>결제 금액 <span id="totalPriceArea">23000원</span></h3>
           </div>
           <div class="col-3">
             <button type="button" class="btn btn-info btn-block">구매하기</button>

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -23,7 +23,7 @@
         //결제 금액 init
         calculateTotalPrice();
 
-        //각 장바구니 상품 내 이벤트 감지
+        //각 장바구니 상품 내 수량 이벤트 감지
         document.querySelectorAll('.quantity').forEach(
 
           function(item) {
@@ -68,7 +68,6 @@
             console.log(error);
           });
 
-
         }
 
         //전체 합계 금액 계산
@@ -105,6 +104,54 @@
             document.getElementById('except-shipping-fee').innerHTML = totalPrice + '원'; //배송비 제외 금액
             document.getElementById('totalPriceArea').innerHTML = addFeeTotalPrice + '원'; //배송비 합친 금액
           }
+
+        }
+
+        //장바구니 상품 삭제 버튼 이벤트
+        document.querySelectorAll('.delete-btn').forEach(
+
+          function(item) {
+            item.querySelector('button[type=button]').addEventListener('click', function() {
+
+              let deleteProductParam = {
+                cartItemId: this.value
+              };
+
+              console.log('deleteparameter 확인');
+              console.log(deleteProductParam);
+              deleteProduct(deleteProductParam);
+            })
+          }
+
+        );
+
+
+        //장바구니 상품 삭제 처리
+        function deleteProduct(deleteProductParam) {
+
+          let url = '/api/cart/delete-product-req';
+          //delete -> config 내 data 속성으로 보내주어야 api에서 @RequestBody parameter 받을 수 있음
+          //구조분해할당 ... -> config 중, data 속성만 든 것을 컨트롤러로 전송
+          axios.delete(url, {headers: {'Content-Type': `application/json`}, data: {...deleteProductParam}}).then(function(response) {
+
+            response.data = response.data || {};
+            response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+            //fail
+            if (!response.data.responseResultHeader.result) {
+              alert('내부 서버 오류로 인해 장바구니 상품이 삭제되지 않았습니다.');
+              return false;
+            }
+
+            //success
+            //load page
+            location.href = '/cart/list';
+
+          }).catch(function(error) {
+
+            console.log(error);
+          });
+
 
         }
 
@@ -223,9 +270,9 @@
                 </h2>
               </div>
             </td>
-            <td class="col-2">
+            <td class="col-2 delete-btn">
               <!-- btns -->
-              <button type="button" class="btn btn-outline-info btn-block">삭제</button>
+              <button type="button" th:value="${cartItem.cartItemId}" class="btn btn-outline-info btn-block">삭제</button>
             </td>
           </tr>
         </tbody>

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -20,6 +20,60 @@
 
       window.addEventListener('DOMContentLoaded', function(){
 
+        document.querySelectorAll('.quantity').forEach(
+
+          function(item) {
+            //수량 value change event 감지
+            item.querySelector('input[type=number]').addEventListener('change', function() {
+
+              let changeProductParam = {
+                cartItemId: this.parentNode.querySelector('input[type=hidden]').value
+                , quantity: this.value
+              }
+
+              console.log('확인');
+              console.log(changeProductParam);
+              changeProductQuantity(changeProductParam);
+
+            });
+          }
+
+        );
+
+        //수량 input value 변경 시, 상품 row 한개의 값 변경
+        function changeProductQuantity(changeProductParam) {
+
+          let url = '/api/cart/update-quantity-req';
+
+          axios.put(url, changeProductParam).then(function(response) {
+
+            response.data = response.data || {};
+            response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+            //fail
+            if (!response.data.responseResultHeader.result) {
+              alert('내부 서버 오류로 인해 장바구니 상품 수량이 변경되지 않았습니다.');
+              return false;
+            }
+
+            //success
+            //ui init call (전체 합계 금액)
+            calculateTotalPrice();
+
+          }).catch(function(error) {
+
+            console.log(error);
+          });
+
+
+        }
+
+        //전체 합계 금액 계산
+        function calculateTotalPrice() {
+          console.log('calculateTotalPrice coll 확인');
+        }
+
+
 
 
 
@@ -120,14 +174,17 @@
             </td>
             <td class="col-2">
               <!-- quantity  -->
-              <div class="form-group">
-                <label for="quantity_1">수량</label>
-                <input th:value="${cartItem.quantity}" type="number" class="form-control" id="quantity_1" name="quantity_1" />
+              <div class="form-group quantity">
+                <label th:for="'quantity_' + ${cartItem.cartItemId}">수량</label>
+                <input th:value="${cartItem.quantity}" type="number" class="form-control" th:id="'quantity_' + ${cartItem.cartItemId}" th:name="'quantity_' + ${cartItem.cartItemId}" />
+                <input type="hidden" th:value="${cartItem.cartItemId}"> <!-- 장바구니 상품 Key value -->
               </div>
             </td>
             <td class="col-4">
-              <!-- amount -->
-              <h2><span th:text="${cartItem.price}" class="badge badge-pill badge-light"></span>원</h2>
+              <!-- price -->
+              <div class="price">
+                <h2><span th:text="${cartItem.price}" class="badge badge-pill badge-light price"></span>원</h2>
+              </div>
             </td>
             <td class="col-2">
               <!-- btns -->

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -20,6 +20,10 @@
 
       window.addEventListener('DOMContentLoaded', function(){
 
+        //결제 금액 init
+        calculateTotalPrice();
+
+        //각 장바구니 상품 내 이벤트 감지
         document.querySelectorAll('.quantity').forEach(
 
           function(item) {
@@ -31,8 +35,7 @@
                 , quantity: this.value
               };
 
-              console.log('확인');
-              console.log(changeProductParam);
+              //장바구니 수량 update
               changeProductQuantity(changeProductParam);
 
             });
@@ -57,7 +60,7 @@
             }
 
             //success
-            //ui init call (전체 합계 금액)
+            //전체 합계 금액 계산 call
             calculateTotalPrice();
 
           }).catch(function(error) {
@@ -70,28 +73,38 @@
 
         //전체 합계 금액 계산
         function calculateTotalPrice() {
-          console.log('calculateTotalPrice coll 확인');
 
           let totalPrice = 0;
 
           document.querySelectorAll('.price').forEach(
             function(item) {
-              console.log('item확인확인');
-              console.log(item);
 
               let price = item.querySelector('span').innerHTML;
-              console.log('가격확인확인--->' + price);
 
               let quantity = item.parentNode.parentNode.parentNode.querySelector('input[type=number]').value;
-              console.log('부모요소요소000>');
-              console.log(quantity);
-
 
               totalPrice += price * quantity;
             }
           );
 
-          document.getElementById('totalPriceArea').innerHTML = totalPrice + '원';
+          // 합계 금액 30,000원 이상 시, 배송비 무료
+          if (totalPrice >= 30000) {
+
+            let shippingFee = 0; //배송비
+            let addFeeTotalPrice = totalPrice + shippingFee;
+
+            document.getElementById('shipping-fee').innerHTML = shippingFee + '원'; //배송비
+            document.getElementById('except-shipping-fee').innerHTML = totalPrice + '원'; //배송비 제외 금액
+            document.getElementById('totalPriceArea').innerHTML = totalPrice + '원'; //배송비 합친 금액
+          } else if (totalPrice > 0) {
+
+            let shippingFee = 3000; //배송비
+            let addFeeTotalPrice = totalPrice + shippingFee;
+
+            document.getElementById('shipping-fee').innerHTML = shippingFee + '원'; //배송비
+            document.getElementById('except-shipping-fee').innerHTML = totalPrice + '원'; //배송비 제외 금액
+            document.getElementById('totalPriceArea').innerHTML = addFeeTotalPrice + '원'; //배송비 합친 금액
+          }
 
         }
 
@@ -227,13 +240,14 @@
       <div class="container-md">
         <div class="row alert alert-light">
           <div class="col-3">
-            총 상품금액 <br/> <span>20000</span> 원 <br/>
+            총 상품금액 <br/> <span id="except-shipping-fee"></span> <br/>
           </div>
           <div class="col-3">
-            배송비 (금액 30,000원 이상 무료) <br/> + <span>3000</span> 원 <br/>
+            배송비 (금액 30,000원 이상 무료) <br/> + <span id="shipping-fee"></span> <br/>
           </div>
           <div class="col-3">
-            <h3>결제 금액 <span id="totalPriceArea">23000원</span></h3>
+            <h3>결제 금액 <span id="totalPriceArea"></span>
+            </h3>
           </div>
           <div class="col-3">
             <button type="button" class="btn btn-info btn-block">구매하기</button>


### PR DESCRIPTION
:white_check_mark: Changes

- 고객의 장바구니 페이지 조회 시, 수량값 변경 후, 총 계산 금액을 하단에서 볼 수 있도록 update api와 javasciprt 추가했습니다.
- 고객이 본인 장바구니의 상품을 삭제할 수 있도록 delete api와 javascript 추가했습니다.

<br>

:heavy_plus_sign: Related Details

- 장바구니 내에서 사용되는 기능들 (장바구니상품 수량 update, 장바구니상품 delete)는 @RestController 어노테이션을 사용해서 json으로 parameter 받아오고, json으로 응답값을 다시 보내주는 식으로 작성하였습니다.
![장바구니](https://user-images.githubusercontent.com/65488155/211474456-0db9af14-0619-42c7-83ad-ee33c207982a.jpg)

- 제로베이스 학습관리 시스템에서 사용한 방식과 동일하게 axios 라이브러리를 사용해서 컨트롤러 - 화면 간 통신 하였습니다.
(promise 객체로 비동기로 호출하고, .then으로 호출 결과 응답값에 따라서 결과처리)

<br>

:pray: To Reviewers
- 장바구니 내에서 상품수량 update가 db에 반영되려면 수량 값이 바뀐 부분만 요청해서 update하면 되어서, axios로 update 요청 보내서 그 부분만 update하는 것으로 구현했습니다. 하고 보니.. 삭제도 동일한 형태로 진행하는 게 좋겠다 싶어서 form 전송이 아니라 axios로 컨트롤러 (@DeleteMapping 사용) 을 호출하는 것으로 작성했습니다.(장바구니 상품 data를 아예 delete하는 것으로 작성)
- 장바구니 상품 삭제 기능은 @DeleteMapping을 사용 + axios 라이브러리 사용 + 삭제용 컨트롤러에서 삭제할 상품 key 값을 @ RequestBody 써서 json으로 body에 받아오는 조합을 사용하였는데 구현 방향이 올바른지는 확인 중입니다.
- @DeleteMapping은 스프링 버전에 따라서 body에 값을 받아올 수 없다고 합니다..
[참고링크]
 https://dogpaw.tistory.com/4
- axios 부분 또한 post 요청이나 put 요청은 강의내용과 동일하게 `axios.put(url, requestParameter)` 이 형식을 사용해도 되나,
delete 요청을 할 때, parameter 값을 body로 보내야 한다면 
`axios.delete(url, {headers: {'Content-Type': `application/json`}, data: {...requestParameter}})`   이런 식으로 세팅을 해주어야 합니다.
[참고링크]
1) https://masteringjs.io/tutorials/axios/delete-with-body
 2) https://velog.io/@reum107/Axios-delete%EC%9A%94%EC%B2%AD-%EC%8B%9C-body-%EC%95%88%EC%97%90-%EA%B0%92%EC%9D%84-%EB%84%A3%EB%8A%94-%EB%B0%A9%EB%B2%95%EA%B3%BC-%EB%93%A4%EC%96%B4%EA%B0%80%EC%A7%80-%EC%95%8A%EB%8A%94-%EC%9D%B4%EC%9C%A0

- @DeleteMapping 어노테이션을 사용하고, 해당 컨트롤러가 @RequestBody로 body json 값을 요청값으로 사용하는 것이 현재 스프링부트 버전에서는 가능하나 다운 버전의 스프링에서는 불가합니다.