### PR TITLE
커스텀 익셉션 만들기

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,20 @@
 			<scope>provided</scope>
 		</dependency>
 		-->
+
+		<!-- swagger -->
 		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-boot-starter</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>3.0.0</version>
+		</dependency>
+
+	<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -5,6 +5,7 @@ import com.shoptest.catmart.cart.dto.CartItemDeleteInputDto;
 import com.shoptest.catmart.cart.dto.CartItemUpdateInputDto;
 import com.shoptest.catmart.cart.service.CartService;
 import com.shoptest.catmart.common.model.ResponseResult;
+import io.swagger.annotations.ApiOperation;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +24,7 @@ public class ApiCartController {
 
   private final CartService cartService;
 
-  //장바구니 상품 담기
+  @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니에 장바구니 상품을 담습니다.", notes = "장바구니 상품 data isnert or update")
   @PostMapping("/api/cart/add-req")
   public ResponseEntity<?> cartAddReq(
       Model model
@@ -42,7 +43,7 @@ public class ApiCartController {
     return ResponseEntity.ok().body(responseResult);
   }
 
-  //장바구니 내역 조회 - 장바구니 상품 수량 변경
+  @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품 수량을 변경합니다.", notes ="장바구니 상품 수량 update")
   @PutMapping("/api/cart/update-quantity-req")
   public ResponseEntity<?> cartProductQuantityUpdate(
       Model model
@@ -61,7 +62,8 @@ public class ApiCartController {
     return ResponseEntity.ok().body(responseResult);
   }
 
-  //장바구니 내역 조회 - 장바구니 상품 삭제
+
+  @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품을 삭제합니다.", notes="장바구니 상품 delete")
   @DeleteMapping("/api/cart/delete-product-req")
   public ResponseEntity<?> cartProductDelete(
       Model model

--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -14,9 +14,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
@@ -10,6 +10,8 @@ import com.shoptest.catmart.cart.mapper.CartMapper;
 import com.shoptest.catmart.cart.repository.CartItemRepository;
 import com.shoptest.catmart.cart.repository.CartRepository;
 import com.shoptest.catmart.cart.service.CartService;
+import com.shoptest.catmart.common.exception.CartException;
+import com.shoptest.catmart.common.exception.type.CartErrorCode;
 import com.shoptest.catmart.member.domain.Member;
 import com.shoptest.catmart.member.repository.MemberRepository;
 import com.shoptest.catmart.product.domain.ProductItem;
@@ -42,8 +44,7 @@ public class CartServiceImpl implements CartService {
     //1. member data check
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
     if (!optionalMember.isPresent()) {
-      //exception 처리 필요 -> 로그인 정보(email) 로 찾은 member data가 없을 때의 예외 처리
-      return null;
+      throw new CartException(CartErrorCode.USER_EMAIL_NOT_EXIST);
     }
     Member member = optionalMember.get();
 
@@ -66,7 +67,10 @@ public class CartServiceImpl implements CartService {
 
     //3. cartItem data check (by FK (cartId, productItemId))
     Optional<ProductItem> optionalProductItem = productItemRepository.findById(parameter.getProductItemId());
-    ProductItem wishProductItem = optionalProductItem.get(); //특정 상품상세 page 내에서 쓰이는 api이기 때문에 상품 ID에 대한 상품 value는 항상 있다고 가정?.. 보단 exception 추가 필요.
+    if (!optionalProductItem.isPresent()) {
+      throw new CartException(CartErrorCode.PRODUCT_ITEM_NOT_EXIST);
+    }
+    ProductItem wishProductItem = optionalProductItem.get();
 
     Optional<CartItem> optionalCartItem = cartItemRepository.findByCartCartIdAndProductItemProductItemId(
         cartOfMember.getCartId(), parameter.getProductItemId());
@@ -101,8 +105,7 @@ public class CartServiceImpl implements CartService {
     //1. member data
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
     if (!optionalMember.isPresent()) {
-      //exception 처리 필요 -> 로그인 정보(email) 로 찾은 member data가 없을 때의 예외 처리
-      return null;
+      throw new CartException(CartErrorCode.USER_EMAIL_NOT_EXIST);
     }
     Member member = optionalMember.get();
 
@@ -116,16 +119,14 @@ public class CartServiceImpl implements CartService {
     //1. member data check
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
     if (!optionalMember.isPresent()) {
-      //exception 처리 필요 -> 로그인 정보(email) 로 찾은 member data가 없을 때의 예외 처리
-      return null;
+      throw new CartException(CartErrorCode.USER_EMAIL_NOT_EXIST);
     }
     Member member = optionalMember.get();
 
     //2. cart data check
     Optional<Cart> optionalCart = cartRepository.findByMemberMemberId(member.getMemberId());
     if (!optionalCart.isPresent()) {
-      //exception 처리 필요 -> 해당 회원의 장바구니가 없는 셈... 익셉션 처리 필요.
-      return null;
+      throw new CartException(CartErrorCode.USER_CART_NOT_EXIST);
     }
 
     //3. product data check
@@ -134,8 +135,7 @@ public class CartServiceImpl implements CartService {
     //4. cartItem update
     Optional<CartItem> optionalCartItem = cartItemRepository.findById(parameter.getCartItemId());
     if (!optionalCartItem.isPresent()) {
-      //exception 처리 필요 -> 해당 장바구니 상품이 존재하지 않는 셈.. 익셉션
-      return null;
+      throw new CartException(CartErrorCode.USER_CART_ITEM_NOT_EXIST);
     }
     CartItem cartItem = optionalCartItem.get();
     cartItem.setQuantity(parameter.getQuantity());
@@ -152,16 +152,14 @@ public class CartServiceImpl implements CartService {
     //member data check
     Optional<Member> optionalMember = memberRepository.findByEmail(email);
     if (!optionalMember.isPresent()) {
-      //exception.. member
-      return null;
+      throw new CartException(CartErrorCode.USER_EMAIL_NOT_EXIST);
     }
     Member member = optionalMember.get();
 
     //cart data check
     Optional<Cart> optionalCart = cartRepository.findByMemberMemberId(member.getMemberId());
     if (!optionalCart.isPresent()) {
-      //exception.. cart
-      return null;
+      throw new CartException(CartErrorCode.USER_CART_NOT_EXIST);
     }
     Cart cart = optionalCart.get();
 

--- a/src/main/java/com/shoptest/catmart/common/exception/CartException.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/CartException.java
@@ -1,0 +1,28 @@
+package com.shoptest.catmart.common.exception;
+
+import com.shoptest.catmart.common.exception.type.CartErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/*
+* 장바구니 업무 - custom exception
+* */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CartException extends RuntimeException{
+
+  private CartErrorCode cartErrorCode;
+  private String errorMessage;
+
+  public CartException(CartErrorCode cartErrorCode) {
+    this.cartErrorCode = cartErrorCode;
+    this.errorMessage = cartErrorCode.getDescription();
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.shoptest.catmart.common.exception;
+
+import com.shoptest.catmart.common.exception.model.CartErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  /*
+  * 장바구니 API 호출 에러 핸들러
+  * */
+  @ResponseBody
+  @ExceptionHandler(CartException.class)
+  public CartErrorResponse handleCartException(CartException e) {
+
+    log.error("{} is ocurred.", e.getCartErrorCode());
+    return new CartErrorResponse(e.getCartErrorCode(), e.getErrorMessage());
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
@@ -2,9 +2,11 @@ package com.shoptest.catmart.common.exception;
 
 import com.shoptest.catmart.common.exception.model.CartErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Slf4j
 @ControllerAdvice
@@ -14,6 +16,7 @@ public class GlobalExceptionHandler {
   * 장바구니 API 호출 에러 핸들러
   * */
   @ResponseBody
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(CartException.class)
   public CartErrorResponse handleCartException(CartException e) {
 

--- a/src/main/java/com/shoptest/catmart/common/exception/model/CartErrorResponse.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/model/CartErrorResponse.java
@@ -1,0 +1,22 @@
+package com.shoptest.catmart.common.exception.model;
+
+import com.shoptest.catmart.common.exception.type.CartErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+/**
+ *  장바구니 API 에러 공통 응답 객체
+ * */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CartErrorResponse {
+
+  private CartErrorCode errorCode;
+  private String errorMessage;
+
+}

--- a/src/main/java/com/shoptest/catmart/common/exception/type/CartErrorCode.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/type/CartErrorCode.java
@@ -1,0 +1,16 @@
+package com.shoptest.catmart.common.exception.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CartErrorCode {
+
+  USER_EMAIL_NOT_EXIST("해당 이메일을 가진 사용자가 없습니다.")
+  , USER_CART_NOT_EXIST("장바구니 관련 내부 서버 오류로 장바구니 상품의 상태 변경이 어렵습니다.")
+  , USER_CART_ITEM_NOT_EXIST("장바구니 관련 내부 서버 오류로 장바구니 상품의 상태 변경이 어렵습니다.")
+  , PRODUCT_ITEM_NOT_EXIST("선택하신 상품은 현재 장바구니에 담을 수 없는 상품입니다.");
+
+  private final String description;
+}

--- a/src/main/java/com/shoptest/catmart/configuration/SwaggerConfiguration.java
+++ b/src/main/java/com/shoptest/catmart/configuration/SwaggerConfiguration.java
@@ -1,0 +1,50 @@
+//package com.shoptest.catmart.configuration;
+//
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//import springfox.documentation.builders.ApiInfoBuilder;
+//import springfox.documentation.builders.PathSelectors;
+//import springfox.documentation.builders.RequestHandlerSelectors;
+//import springfox.documentation.service.ApiInfo;
+//import springfox.documentation.spi.DocumentationType;
+//import springfox.documentation.spring.web.plugins.Docket;
+//import springfox.documentation.swagger2.annotations.EnableSwagger2;
+//
+//@Configuration
+//@EnableSwagger2
+//public class SwaggerConfiguration { //extends WebMvcConfigurationSupport
+//
+//
+////  @Override
+////  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+//////    registry.addResourceHandler("/swagger-ui/**")
+//////        .addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
+//////
+//////    registry.addResourceHandler("/webjars/**")
+//////        .addResourceLocations("classpath:/META-INF/resources/webjars/springfox-swagger-ui/");
+////
+////    registry.addResourceHandler("/swagger-ui/**")
+////        .addResourceLocations("classpath:/META-INF/resources/webjars/swagger-ui/2.7.0/");
+////  }
+//
+//  @Bean
+//  public Docket api() {
+//    return new Docket(DocumentationType.SWAGGER_2)
+//        .select()
+//        .apis(RequestHandlerSelectors.basePackage("com.shoptest.catmart.cart"))
+//        .paths(PathSelectors.any())
+//        .build().apiInfo(cartApiInfo());
+//  }
+//
+//  private ApiInfo cartApiInfo() {
+//    return new ApiInfoBuilder()
+//        .title("CAT_MART 장바구니 API")
+//        .description("CAT_MART의 장바구니 상품을 CRUD하는 API입니다.")
+//        .version("1.0")
+//        .build();
+//  }
+//
+//}

--- a/src/main/java/com/shoptest/catmart/configuration/WebConfig.java
+++ b/src/main/java/com/shoptest/catmart/configuration/WebConfig.java
@@ -1,12 +1,25 @@
 package com.shoptest.catmart.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
+
+//@EnableWebMvc
+@EnableSwagger2
 @Configuration
-public class WebConfig implements WebMvcConfigurer {
+public class WebConfig implements WebMvcConfigurer { //implements WebMvcConfigurer extends WebMvcConfigurationSupport
 
 
   @Value("${uploadPath}")
@@ -14,9 +27,36 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addResourceHandlers(ResourceHandlerRegistry registry) {
-
+    //이미지 data url_path html에서 출력 설정
     registry.addResourceHandler("/images/**")
         .addResourceLocations(uploadPath);
 
+//    //swagger config
+//    (swagger ui를 가져오기 위해 이곳에서 설정을 추가해 주어야만 http://localhost:8080/swagger-ui/index.html 로 api 확인이 가능.. )
+      registry.addResourceHandler("swagger-ui.html")
+          .addResourceLocations("classpath:/META-INF/resources/");
+      registry.addResourceHandler("/webjars/**")
+          .addResourceLocations("classpath:/META-INF/resources/webjars/");
   }
+
+  //swagger config
+  @Bean
+  public Docket api() {
+    return new Docket(DocumentationType.SWAGGER_2)
+        .select()
+        .apis(RequestHandlerSelectors.basePackage("com.shoptest.catmart.cart"))
+        .paths(PathSelectors.any())
+        .build().apiInfo(cartApiInfo());
+  }
+
+  private ApiInfo cartApiInfo() {
+    return new ApiInfoBuilder()
+        .title("CAT_MART 장바구니 API")
+        .description("CAT_MART의 장바구니 상품을 CRUD하는 API입니다.")
+        .version("1.0")
+        .build();
+  }
+
+
 }
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,10 @@ spring:
       max-file-size: 100MB
       max-request-size: 100MB
 
+  mvc:
+    pathmatch:
+      matching-strategy: ant_path_matcher
+
 logging:
   level:
     root: info

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -293,8 +293,8 @@
             배송비 (금액 30,000원 이상 무료) <br/> + <span id="shipping-fee"></span> <br/>
           </div>
           <div class="col-3">
-            <h3>결제 금액 <span id="totalPriceArea"></span>
-            </h3>
+            <h4>결제 금액 <span id="totalPriceArea"></span>
+            </h4>
           </div>
           <div class="col-3">
             <button type="button" class="btn btn-info btn-block">구매하기</button>

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -65,6 +65,12 @@
 
           }).catch(function(error) {
 
+            if (error.response) {
+              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
+              console.log(error.response.data);
+              alert(error.response.data.errorMessage);
+            }
+
             console.log(error);
           });
 
@@ -148,6 +154,12 @@
             location.href = '/cart/list';
 
           }).catch(function(error) {
+
+            if (error.response) {
+              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
+              console.log(error.response.data);
+              alert(error.response.data.errorMessage);
+            }
 
             console.log(error);
           });

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -69,6 +69,12 @@
 
           }).catch(function(error) {
 
+            if (error.response) {
+              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
+              console.log(error.response.data);
+              alert(error.response.data.errorMessage);
+            }
+
             console.log(error);
           });
 

--- a/src/test/java/com/shoptest/catmart/cart/ApiCartControllerTest.java
+++ b/src/test/java/com/shoptest/catmart/cart/ApiCartControllerTest.java
@@ -1,0 +1,2 @@
+package com.shoptest.catmart.cart;public class ApiCartControllerTest {
+}


### PR DESCRIPTION
:white_check_mark: Changes

- 장바구니 api 에서 장바구니 업무용 custom exception을 던질 수 있게 코드를 변경하였습니다.
- 전역 익셉션핸들러에서 장바구니 업무용 커스텀 익셉션을 받아와 400코드로 내려주고, 이 api를 활용하는 화면에서 responseBody안에 있는 메시지를 alert창으로 이용자에게 보여줄 수 있도록 코드를 추가했습니다.
- 현재 프로젝트 코드는 대부분 @Controller로 뷰리졸버를 거쳐서 타임리프 뷰 페이지를 보여주는 것을 기반으로 되어있습니다. 장바구니 관련 업무는 @RestController로 json으로 받아와서 json으로 내려주는 api를 쓰기에, api는 swagger문서를 제공하는 것이 좋겠다 싶어서 swagger 디펜던시를 추가하여 swagger ui로 정리된 api를 볼 수 있도록 하였습니다.


<br>

:heavy_plus_sign: Related Details

- 제가 아직 테스트 코드와 스프링 시큐리티 간 이슈 처리에 필요한 내용을 숙지하지 못한 관계로 우선 커밋 이전 커스텀 익셉션이 잘 동작하는지에 대한 기능 테스트는 swagger 문서를 활용하여 진행하였습니다.

[기능테스트 요약]

- 1) swagger로 로컬 DB에 없는 상품값(productItemId: 0)을 parameter로 해서 장바구니 상품을 add하는 요청을 보냅니다. 
![스웨거test1](https://user-images.githubusercontent.com/65488155/212035220-ea232f89-fc51-4b8c-ad19-eae9b088387e.jpg)

- 2) 전역 익셉션 핸들러 내 메서드에서 지정한대로 400 status로 반환하며, 커스텀 익셉션 내의 메시지가 담긴 것을 확인합니다.
![스웨거test2](https://user-images.githubusercontent.com/65488155/212035949-7a39c526-1f9a-41c8-9252-c78a680a00ee.jpg)

- 3) 스웨거로 api에서 커스텀 익셉션이 정상 동작함을 확인했기에, 화면단에서 이 메시지를 alert창에서 정상 출력할 수 있는지
화면단 parameter를 에러가 일어나도록 임의로 바꿔서(productItemId: 0) axios로 요청합니다.
![화면단에서의에러처리](https://user-images.githubusercontent.com/65488155/212037267-1790785d-5173-46ec-84e9-6a714fcfd340.jpg)

- 4) 정상 동작함을 확인하였습니다.
![요청확인](https://user-images.githubusercontent.com/65488155/212037648-2d0c78c0-0880-480b-aef7-9d9d76b7d9ad.jpg)
![화면단에러출력확인](https://user-images.githubusercontent.com/65488155/212037969-227feb68-0137-4987-8232-ac3406423029.jpg)


<br>

:pray: To Reviewers
- 챌린지 반 내의 가이드 방향이 일관되게 다양한 기능 구현에 초점을 맞추기보단 요구사항 내의 기능을 안정적으로 수행할 수 있는 코드를 짜는 데 필요한 이해를 더하는 것을 강조하신 것 같아 주문 기능 구현 전, 부족한 사항(null로 리턴하는 것으로 뭉개서 기능 구현) 을 보완해서 익셉션으로 처리하도록 코드를 변경했습니다.
- @Controller로 뷰를 매치시켜 보여주는 형태가 기반인 프로젝트에서 swagger를 적용하려니 WebConfig가 충돌(?).. swagger의 ui를 웹에서 볼 수가 없는 이슈가 있었어서, 구글링 후 이를 해결하였습니다. 만약 Rest API로만 구성된 프로젝트라면 해당 이슈는 발생하지 않습니다.(ex: 제로베이스 weather_project) 
[스웨거 이슈 관련 참고 링크]
https://pipe0502.tistory.com/entry/swagger2-Whitelabel-Error-Page
https://oingdaddy.tistory.com/410

- 커스텀 익셉션을 통해 지정한 응답값을 화면단에서 처리하는 방식은 해당 링크를 통해 axios 응답 상태에 따라 응답을 받고 서버에서 200으로 내려주지 않으니 catch절에 걸리는 것을 alert로 출력하도록 했습니다.
[axios 관련 참고 링크]
https://yamoo9.github.io/axios/guide/error-handling.html 
