### PR TITLE
Rest API 가이드 확인후 URL 수정 + 주문 데이터 생성 API 추가

### DIFF
--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,7 +26,7 @@ public class ApiCartController {
   private final CartService cartService;
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니에 장바구니 상품을 담습니다.", notes = "장바구니 상품 data isnert or update")
-  @PostMapping("/api/cart/add-req")
+  @PostMapping("/api/cart/addCartItem")
   public ResponseEntity<?> addCartItem(Model model, @RequestBody CartItemAddInputDto parameter, Principal principal) {
 
     String email = principal.getName();
@@ -36,7 +37,7 @@ public class ApiCartController {
   }
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품 수량을 변경합니다.", notes ="장바구니 상품 수량 update")
-  @PutMapping("/api/cart/update-quantity-req")
+  @PutMapping("/api/cart/updateItemsQuantity")
   public ResponseEntity<?> updateCartProductQuantity(Model model, @RequestBody CartItemUpdateInputDto parameter, Principal principal) {
 
     String email = principal.getName();
@@ -48,12 +49,12 @@ public class ApiCartController {
 
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품을 삭제합니다.", notes="장바구니 상품 delete")
-  @DeleteMapping("/api/cart/delete-product-req")
-  public ResponseEntity<?> deleteCartProduct(Model model, @RequestBody CartItemDeleteInputDto parameter, Principal principal) {
+  @DeleteMapping("/api/cart/deleteProduct/{cartItemId}")
+  public ResponseEntity<?> deleteCartProduct(Model model, @PathVariable("cartItemId") Long cartItemId, Principal principal) {
 
     String email = principal.getName();
 
-    Long deletedCartItemId = cartService.deleteItemInCart(email, parameter);
+    Long deletedCartItemId = cartService.deleteItemInCart(email, cartItemId);
 
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);

--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -31,11 +31,6 @@ public class ApiCartController {
     String email = principal.getName();
     Long savedCartItemId = cartService.addItemInCart(email, parameter);
 
-//    if (savedCartItemId == null) {
-//      ResponseResult responseResult = new ResponseResult(false);
-//      return ResponseEntity.ok().body(responseResult);
-//    }
-
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);
   }
@@ -46,11 +41,6 @@ public class ApiCartController {
 
     String email = principal.getName();
     Long updatedCartItemId = cartService.updateItemQuantityInCart(email, parameter);
-
-//    if (updatedCartItemId == null) {
-//      ResponseResult responseResult = new ResponseResult(false);
-//      return ResponseEntity.ok().body(responseResult);
-//    }
 
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);
@@ -64,10 +54,6 @@ public class ApiCartController {
     String email = principal.getName();
 
     Long deletedCartItemId = cartService.deleteItemInCart(email, parameter);
-//    if (deletedCartItemId == null) {
-//      ResponseResult responseResult = new ResponseResult(false);
-//      return ResponseEntity.ok().body(responseResult);
-//    }
 
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);

--- a/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
+++ b/src/main/java/com/shoptest/catmart/cart/controller/ApiCartController.java
@@ -26,7 +26,7 @@ public class ApiCartController {
   private final CartService cartService;
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니에 장바구니 상품을 담습니다.", notes = "장바구니 상품 data isnert or update")
-  @PostMapping("/api/cart/addCartItem")
+  @PostMapping("/api/cart/cartItem")
   public ResponseEntity<?> addCartItem(Model model, @RequestBody CartItemAddInputDto parameter, Principal principal) {
 
     String email = principal.getName();
@@ -37,7 +37,7 @@ public class ApiCartController {
   }
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품 수량을 변경합니다.", notes ="장바구니 상품 수량 update")
-  @PutMapping("/api/cart/updateItemsQuantity")
+  @PutMapping("/api/cart/cartItem")
   public ResponseEntity<?> updateCartProductQuantity(Model model, @RequestBody CartItemUpdateInputDto parameter, Principal principal) {
 
     String email = principal.getName();
@@ -49,7 +49,7 @@ public class ApiCartController {
 
 
   @ApiOperation(value="장바구니 - 로그인한 고객의 장바구니 내 상품을 삭제합니다.", notes="장바구니 상품 delete")
-  @DeleteMapping("/api/cart/deleteProduct/{cartItemId}")
+  @DeleteMapping("/api/cart/cartItem/{cartItemId}")
   public ResponseEntity<?> deleteCartProduct(Model model, @PathVariable("cartItemId") Long cartItemId, Principal principal) {
 
     String email = principal.getName();

--- a/src/main/java/com/shoptest/catmart/cart/dto/CartItemUpdateInputDto.java
+++ b/src/main/java/com/shoptest/catmart/cart/dto/CartItemUpdateInputDto.java
@@ -8,12 +8,15 @@ import lombok.Setter;
  * */
 @Getter
 @Setter
-public class CartItemUpdateInputDto {
+public class  CartItemUpdateInputDto {
 
   /* 상품 Id */
   private Long cartItemId;
 
   /* 장바구니_상품 개수 */
   private int quantity;
+
+  /* 해당 상품 재고 */
+  private int stock;
 
 }

--- a/src/main/java/com/shoptest/catmart/cart/repository/CartItemRepository.java
+++ b/src/main/java/com/shoptest/catmart/cart/repository/CartItemRepository.java
@@ -10,4 +10,6 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
   Long deleteByCartCartIdAndCartItemId(Long cartId, Long cartItemId);
 
+  void deleteByCartCartId(Long cartId);
+
 }

--- a/src/main/java/com/shoptest/catmart/cart/service/CartService.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/CartService.java
@@ -21,4 +21,7 @@ public interface CartService {
   /* 고객 - 장바구니 내역 목록 > 장바구니 상품 삭제 */
   Long deleteItemInCart(String email, CartItemDeleteInputDto parameter);
 
+  /* 주문 처리 이후, 고객의 장바구니_상품 일괄 삭제 */
+  void deleteAllCartItem(Long cartId);
+
 }

--- a/src/main/java/com/shoptest/catmart/cart/service/CartService.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/CartService.java
@@ -19,7 +19,7 @@ public interface CartService {
   Long updateItemQuantityInCart(String email, CartItemUpdateInputDto parameter);
 
   /* 고객 - 장바구니 내역 목록 > 장바구니 상품 삭제 */
-  Long deleteItemInCart(String email, CartItemDeleteInputDto parameter);
+  Long deleteItemInCart(String email, Long cartItemId);
 
   /* 주문 처리 이후, 고객의 장바구니_상품 일괄 삭제 */
   void deleteAllCartItem(Long cartId);

--- a/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
@@ -134,6 +134,11 @@ public class CartServiceImpl implements CartService {
     return cartItemRepository.deleteByCartCartIdAndCartItemId(cart.getCartId(), parameter.getCartItemId());
   }
 
+  @Override
+  public void deleteAllCartItem(Long cartId) {
+    cartItemRepository.deleteByCartCartId(cartId);
+  }
+
   private Member getMember(String email) {
 
     return memberRepository.findByEmail(email)

--- a/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
@@ -122,7 +122,7 @@ public class CartServiceImpl implements CartService {
 
   @Transactional
   @Override
-  public Long deleteItemInCart(String email, CartItemDeleteInputDto parameter) {
+  public Long deleteItemInCart(String email, Long cartItemId) {
 
     //member data check
     Member member = getMember(email);
@@ -131,7 +131,7 @@ public class CartServiceImpl implements CartService {
     Cart cart = validateCartExistence(member);
 
     //cartItem data delete
-    return cartItemRepository.deleteByCartCartIdAndCartItemId(cart.getCartId(), parameter.getCartItemId());
+    return cartItemRepository.deleteByCartCartIdAndCartItemId(cart.getCartId(), cartItemId);
   }
 
   @Override

--- a/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/cart/service/impl/CartServiceImpl.java
@@ -53,6 +53,12 @@ public class CartServiceImpl implements CartService {
     ProductItem wishProductItem = productItemRepository.findById(parameter.getProductItemId())
         .orElseThrow(() -> new CartException(CartErrorCode.PRODUCT_ITEM_NOT_EXIST));
 
+    //product data check
+    //주문 확인서에서 수량 바꾸기 불가능함. 이용자 편의성 위해 처음 장바구니에서 수량 update 이벤트 발생 시, 재고 이상으로 수량 담는 것이 불가능하게끔 익셉션 처리 추가
+    if (wishProductItem.getStock() < parameter.getQuantity()) {
+      throw new CartException(CartErrorCode.OVER_QUANTITY);
+    }
+
     Optional<CartItem> optionalCartItem = cartItemRepository.findByCartCartIdAndProductItemProductItemId(
         cartOfMember.getCartId(), parameter.getProductItemId());
 
@@ -91,16 +97,19 @@ public class CartServiceImpl implements CartService {
   @Override
   public Long updateItemQuantityInCart(String email, CartItemUpdateInputDto parameter) {
 
+    //product data check
+    //주문 확인서에서 수량 바꾸기 불가능함. 이용자 편의성 위해 처음 장바구니에서 수량 update 이벤트 발생 시, 재고 이상으로 수량 담는 것이 불가능하게끔 익셉션 처리 추가
+    if (parameter.getQuantity() > parameter.getStock()) {
+      throw new CartException(CartErrorCode.OVER_QUANTITY);
+    }
+
     //1. member data check
     Member member = getMember(email);
 
     //2. cart data check
     validateCartExistence(member);
 
-    //3. product data check
-    //?? 장바구니는 수량 체크할 필요 없고 주문에서만 체크하도록 요구사항을 정하는 것이 통상적인 rule인지 아니면 장바구니도 수량 체크 - 재고 비교 해야 하는지... 확인 필요
-
-    //4. cartItem update
+    //3. cartItem update
     CartItem cartItem = cartItemRepository.findById(parameter.getCartItemId())
             .orElseThrow(() -> new CartException(CartErrorCode.USER_CART_ITEM_NOT_EXIST));
 

--- a/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.shoptest.catmart.common.exception;
 
 import com.shoptest.catmart.common.exception.model.CartErrorResponse;
+import com.shoptest.catmart.common.exception.model.OrderErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -12,16 +13,28 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-  /*
-  * 장바구니 API 호출 에러 핸들러
-  * */
+  /**
+   * 장바구니 API 호출 에러 핸들러
+   * */
   @ResponseBody
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler(CartException.class)
   public CartErrorResponse handleCartException(CartException e) {
 
-    log.error("{} is ocurred.", e.getCartErrorCode());
+    log.error("{} is occurred.", e.getCartErrorCode());
     return new CartErrorResponse(e.getCartErrorCode(), e.getErrorMessage());
+  }
+
+  /**
+   * 주문 API 호출 에러 핸들러
+   * */
+  @ResponseBody
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(OrderException.class)
+  public OrderErrorResponse handleOrderException(OrderException e) {
+
+    log.error("{} is occurred.", e.getOrderErrorCode());
+    return new OrderErrorResponse(e.getOrderErrorCode(), e.getErrorMessage());
   }
 
 }

--- a/src/main/java/com/shoptest/catmart/common/exception/OrderException.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/OrderException.java
@@ -1,0 +1,28 @@
+package com.shoptest.catmart.common.exception;
+
+import com.shoptest.catmart.common.exception.type.OrderErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/*
+ * 주문 업무 - custom exception
+ * */
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class OrderException extends RuntimeException {
+
+  private OrderErrorCode orderErrorCode;
+  private String errorMessage;
+
+  public OrderException(OrderErrorCode orderErrorCode) {
+    this.orderErrorCode = orderErrorCode;
+    this.errorMessage = orderErrorCode.getDescription();
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/common/exception/model/OrderErrorResponse.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/model/OrderErrorResponse.java
@@ -1,21 +1,22 @@
 package com.shoptest.catmart.common.exception.model;
 
-import com.shoptest.catmart.common.exception.type.CartErrorCode;
+import com.shoptest.catmart.common.exception.type.OrderErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
 /**
- *  장바구니 API 에러 공통 응답 객체
+ *  주문 API 에러 공통 응답 객체
  * */
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CartErrorResponse {
+public class OrderErrorResponse {
 
-  private CartErrorCode errorCode;
+  private OrderErrorCode errorCode;
   private String errorMessage;
 }

--- a/src/main/java/com/shoptest/catmart/common/exception/type/CartErrorCode.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/type/CartErrorCode.java
@@ -10,7 +10,8 @@ public enum CartErrorCode {
   USER_EMAIL_NOT_EXIST("해당 이메일을 가진 사용자가 없습니다."),
   USER_CART_NOT_EXIST("장바구니 관련 내부 서버 오류로 장바구니 상품의 상태 변경이 어렵습니다."),
   USER_CART_ITEM_NOT_EXIST("장바구니 관련 내부 서버 오류로 장바구니 상품의 상태 변경이 어렵습니다."),
-  PRODUCT_ITEM_NOT_EXIST("선택하신 상품은 현재 장바구니에 담을 수 없는 상품입니다.");
+  PRODUCT_ITEM_NOT_EXIST("선택하신 상품은 현재 장바구니에 담을 수 없는 상품입니다."),
+  OVER_QUANTITY("담은 상품의 수량이 현재 상품 재고량을 초과합니다.");
 
   private final String description;
 }

--- a/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
@@ -1,0 +1,16 @@
+package com.shoptest.catmart.common.exception.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderErrorCode {
+
+  USER_EMAIL_NOT_EXIST("해당 이메일을 가진 사용자가 없습니다."),
+  OVER_QUANTITY("주문하신 상품의 수량이 현재 상품 재고량을 초과합니다."),
+  OUT_OF_STOCK("주문하신 상품은 현재 품절 상태입니다."),
+  NOT_EXIST_PRODUCT_ITEM("주문하신 상품은 존재하지 않는 상품입니다.");
+
+  private final String description;
+}

--- a/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
@@ -10,7 +10,8 @@ public enum OrderErrorCode {
   USER_EMAIL_NOT_EXIST("해당 이메일을 가진 사용자가 없습니다."),
   OVER_QUANTITY("주문하신 상품의 수량이 현재 상품 재고량을 초과합니다."),
   OUT_OF_STOCK("주문하신 상품은 현재 품절 상태입니다."),
-  NOT_EXIST_PRODUCT_ITEM("주문하신 상품은 존재하지 않는 상품입니다.");
+  NOT_EXIST_PRODUCT_ITEM("주문하신 상품은 존재하지 않는 상품입니다."),
+  NOT_EXIST_CART_ITEM("주문할 수 있는 장바구니 상품을 담아주세요.");
 
   private final String description;
 }

--- a/src/main/java/com/shoptest/catmart/member/domain/Member.java
+++ b/src/main/java/com/shoptest/catmart/member/domain/Member.java
@@ -41,7 +41,10 @@ public class Member {
   
   /* 비밀번호 */
   private String password;
-  
+
+  /* 핸드폰 번호 */
+  private String phoneNumber;
+
   /* 주소 */
   private String address;
   

--- a/src/main/java/com/shoptest/catmart/member/dto/MemberAddressDto.java
+++ b/src/main/java/com/shoptest/catmart/member/dto/MemberAddressDto.java
@@ -2,32 +2,26 @@ package com.shoptest.catmart.member.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+
 /**
- * 회원 DTO
+ * 회원_주소 및 연락처 DTO
  * */
 @Getter
 @Setter
-public class MemberInputDto {
-
-  /* 이메일 */
-  private String email;
+public class MemberAddressDto {
 
   /* 이름 */
   private String name;
 
-  /* 핸드폰번호 */
-  private String phoneNumber;
-
-  /* 비밀번호 */
-  private String password;
-
   /* 주소 */
   private String address;
+
+  /* 핸드폰 번호 */
+  private String phoneNumber;
 
   /* 우편번호 */
   private String zipcode;
 
   /* 상세주소 */
   private String addressDetail;
-
 }

--- a/src/main/java/com/shoptest/catmart/member/service/MemberService.java
+++ b/src/main/java/com/shoptest/catmart/member/service/MemberService.java
@@ -1,16 +1,15 @@
 package com.shoptest.catmart.member.service;
 
+import com.shoptest.catmart.member.dto.MemberAddressDto;
 import com.shoptest.catmart.member.dto.MemberInputDto;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 
 public interface MemberService extends UserDetailsService {
 
-  /**
-   * 회원가입
-   * */
+  /* 회원가입 */
   boolean joinMember(MemberInputDto parameter);
 
-
-
+  /* 고객 - 고객 주소 정보 조회 */
+  MemberAddressDto selectMemberAddress(String email);
 }

--- a/src/main/java/com/shoptest/catmart/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/member/service/impl/MemberServiceImpl.java
@@ -1,6 +1,9 @@
 package com.shoptest.catmart.member.service.impl;
 
+import com.shoptest.catmart.common.exception.CartException;
+import com.shoptest.catmart.common.exception.type.CartErrorCode;
 import com.shoptest.catmart.member.domain.Member;
+import com.shoptest.catmart.member.dto.MemberAddressDto;
 import com.shoptest.catmart.member.dto.MemberInputDto;
 import com.shoptest.catmart.member.repository.MemberRepository;
 import com.shoptest.catmart.member.service.MemberService;
@@ -38,6 +41,7 @@ public class MemberServiceImpl implements MemberService {
         .email(parameter.getEmail())
         .name(parameter.getName())
         .password(encPassword)
+        .phoneNumber(parameter.getPhoneNumber())
         .address(parameter.getAddress())
         .zipcode(parameter.getZipcode())
         .addressDetail(parameter.getAddressDetail())
@@ -47,6 +51,20 @@ public class MemberServiceImpl implements MemberService {
 
     memberRepository.save(member);
     return true;
+  }
+
+  @Override
+  public MemberAddressDto selectMemberAddress(String email) {
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new UsernameNotFoundException("회원 정보가 없습니다."));
+
+    MemberAddressDto memberAddressDto = new MemberAddressDto();
+    memberAddressDto.setName(member.getName());
+    memberAddressDto.setPhoneNumber(member.getPhoneNumber());
+    memberAddressDto.setAddress(member.getAddress());
+    memberAddressDto.setAddressDetail(member.getAddressDetail());
+    memberAddressDto.setZipcode(member.getZipcode());
+    return memberAddressDto;
   }
 
   @Override

--- a/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
@@ -17,7 +17,7 @@ public class ApiOrderController {
 
   private final OrderService orderService;
 
-  @PostMapping("/api/order/from-cart")
+  @PostMapping("/api/orderForCartItem")
   public ResponseEntity<?> createOrderFromCart(Model model, Principal principal) {
 
     String email = principal.getName();

--- a/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
@@ -17,7 +17,7 @@ public class ApiOrderController {
 
   private final OrderService orderService;
 
-  @PostMapping("/api/orderForCartItem")
+  @PostMapping("/api/order/cartItem")
   public ResponseEntity<?> createOrderFromCart(Model model, Principal principal) {
 
     String email = principal.getName();

--- a/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
@@ -1,0 +1,30 @@
+package com.shoptest.catmart.order.controller;
+
+import com.shoptest.catmart.common.model.ResponseResult;
+import com.shoptest.catmart.order.service.OrderService;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class ApiOrderController {
+
+  private final OrderService orderService;
+
+  @PostMapping("/api/order/from-cart")
+  public ResponseEntity<?> createOrderFromCart(Model model, Principal principal) {
+
+    String email = principal.getName();
+    orderService.createOrder(email);
+
+    ResponseResult responseResult = new ResponseResult(true);
+    return ResponseEntity.ok().body(responseResult);
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.shoptest.catmart.order.controller;
 
 import com.shoptest.catmart.cart.service.CartService;
+import com.shoptest.catmart.member.service.MemberService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -14,14 +15,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class OrderController {
 
   private final CartService cartService;
+  private final MemberService memberService;
 
-  @GetMapping
-  public String placeAnOrderForm(Model model, Principal principal) {
+  @GetMapping("/from-cart")
+  public String orderFromCart(Model model, Principal principal) {
 
     String email = principal.getName();
-    model.addAttribute("cartItemList", cartService.selectCartItemDetailList(email));
+    model.addAttribute("shippingAddress", memberService.selectMemberAddress(email)); //배송지 (원래는 배송 관련 내용만 따로 담은 table 필요..)
+    model.addAttribute("cartItemList", cartService.selectCartItemDetailList(email)); //장바구니에 담은 상품 목록
 
-    return "/order/place_an_order";
+    return "/order/order_from_cart";
   }
 
 }

--- a/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
@@ -17,7 +17,7 @@ public class OrderController {
   private final CartService cartService;
   private final MemberService memberService;
 
-  @GetMapping("/from-cart")
+  @GetMapping("/cartItem")
   public String orderFromCart(Model model, Principal principal) {
 
     String email = principal.getName();

--- a/src/main/java/com/shoptest/catmart/order/domain/Orders.java
+++ b/src/main/java/com/shoptest/catmart/order/domain/Orders.java
@@ -1,7 +1,11 @@
 package com.shoptest.catmart.order.domain;
 
+import com.shoptest.catmart.cart.dto.CartItemDetailDto;
+import com.shoptest.catmart.common.exception.OrderException;
+import com.shoptest.catmart.common.exception.type.OrderErrorCode;
 import com.shoptest.catmart.member.domain.Member;
 import com.shoptest.catmart.order.type.OrderStatus;
+import com.shoptest.catmart.product.domain.ProductItem;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +66,30 @@ public class Orders {
 
   /* 수정일자 */
   private LocalDateTime modifiedAt;
+
+  /* 주문_상품 생성하기 */
+  public OrdersItem createOrdersItem(ProductItem productItem, CartItemDetailDto toBeOrderItems) {
+
+    OrdersItem ordersItem = OrdersItem.builder()
+        .orders(this)
+        .quantity(toBeOrderItems.getQuantity())
+        .productItem(productItem)
+        .orderPrice(productItem.getPrice() * toBeOrderItems.getQuantity())
+        .createdAt(LocalDateTime.now())
+        .build();
+    return ordersItem;
+  }
+
+  /* 주문 생성하기 */
+  public Orders createOrders(Member member, Orders orders, List<OrdersItem> ordersItemList) {
+
+    orders.setMember(member);
+    orders.setOrdersItemList(ordersItemList);
+    orders.setOrdersStatus(OrderStatus.PAY_FOR_ORDER);
+    orders.setOrdersDate(LocalDateTime.now());
+    orders.setCreatedAt(LocalDateTime.now());
+    return orders;
+  }
 
 
 }

--- a/src/main/java/com/shoptest/catmart/order/domain/Orders.java
+++ b/src/main/java/com/shoptest/catmart/order/domain/Orders.java
@@ -85,7 +85,7 @@ public class Orders {
 
     orders.setMember(member);
     orders.setOrdersItemList(ordersItemList);
-    orders.setOrdersStatus(OrderStatus.PAY_FOR_ORDER);
+    orders.setOrdersStatus(OrderStatus.TAKE_ORDER);
     orders.setOrdersDate(LocalDateTime.now());
     orders.setCreatedAt(LocalDateTime.now());
     return orders;

--- a/src/main/java/com/shoptest/catmart/order/repository/OrdersItemRepository.java
+++ b/src/main/java/com/shoptest/catmart/order/repository/OrdersItemRepository.java
@@ -1,0 +1,8 @@
+package com.shoptest.catmart.order.repository;
+
+import com.shoptest.catmart.order.domain.OrdersItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersItemRepository extends JpaRepository<OrdersItem, Long> {
+
+}

--- a/src/main/java/com/shoptest/catmart/order/repository/OrdersRepository.java
+++ b/src/main/java/com/shoptest/catmart/order/repository/OrdersRepository.java
@@ -1,0 +1,8 @@
+package com.shoptest.catmart.order.repository;
+
+import com.shoptest.catmart.order.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrdersRepository extends JpaRepository<Orders, Long> {
+
+}

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -1,0 +1,8 @@
+package com.shoptest.catmart.order.service;
+
+public interface OrderService {
+
+  /* 고객 - 주문하기 */
+  void createOrder(String email);
+
+}

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -2,7 +2,7 @@ package com.shoptest.catmart.order.service;
 
 public interface OrderService {
 
-  /* 고객 - 주문하기 */
+  /* 고객 - 주문하기(장바구니에서 접근) */
   void createOrder(String email);
 
 }

--- a/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
@@ -1,0 +1,81 @@
+package com.shoptest.catmart.order.service.impl;
+
+import com.shoptest.catmart.cart.domain.Cart;
+import com.shoptest.catmart.cart.dto.CartItemDetailDto;
+import com.shoptest.catmart.cart.repository.CartRepository;
+import com.shoptest.catmart.cart.service.CartService;
+import com.shoptest.catmart.common.exception.OrderException;
+import com.shoptest.catmart.common.exception.type.OrderErrorCode;
+import com.shoptest.catmart.member.domain.Member;
+import com.shoptest.catmart.member.repository.MemberRepository;
+import com.shoptest.catmart.order.domain.Orders;
+import com.shoptest.catmart.order.domain.OrdersItem;
+import com.shoptest.catmart.order.repository.OrdersRepository;
+import com.shoptest.catmart.order.service.OrderService;
+import com.shoptest.catmart.product.domain.ProductItem;
+import com.shoptest.catmart.product.repository.ProductItemRepository;
+import com.shoptest.catmart.product.type.ItemStatus;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+  private final MemberRepository memberRepository;
+  private final ProductItemRepository productItemRepository;
+  private final CartService cartService;
+  private final CartRepository cartRepository;
+  private final OrdersRepository ordersRepository;
+
+
+  @Transactional
+  @Override
+  public void createOrder(String email) {
+
+    //1. member check
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new OrderException(OrderErrorCode.USER_EMAIL_NOT_EXIST));
+
+    //2. to be orders_item -> check
+    //장바구니에서 진입했을 때 쓰는 메서드 -> 1) 해당 이용자 장바구니_상품 및 해당 상품 정보 select -> 2) 현재 상품 재고 및 상태 체크 -> 3) 주문_상품으로 변환하기 4) 주문에 주문 상품 set
+    //2-1. 현재 이용자의 장바구니 상품 및 해당 상품 정보 모두 가져오기(myBatis 쿼리)
+    List<CartItemDetailDto> cartItemDetailList = cartService.selectCartItemDetailList(email);
+
+    List<OrdersItem> ordersItemList = new ArrayList<>(); //주문 객체 내에 들어갈 자식인 주문 상품 list
+    Orders orders = new Orders(); //해당 메서드 내에서 save할 주문 객체를 미리 생성... (빌터 패턴으로 통일하지 못함...)
+
+    for (CartItemDetailDto cartItem : cartItemDetailList) {
+      //현재 장바구니 내 설정 수량이 재고 초과
+      if (cartItem.getQuantity() > cartItem.getStock()) {
+        throw new OrderException(OrderErrorCode.OVER_QUANTITY);
+      }
+      //상품품절 상태
+      if (ItemStatus.OUT_OF_STOCK.equals(cartItem.getItemStatus())) {
+        throw new OrderException(OrderErrorCode.OUT_OF_STOCK);
+      }
+
+      //3. orders_item create
+      ProductItem productItem = productItemRepository.findById(cartItem.getProductItemId())
+          .orElseThrow(() -> new OrderException(OrderErrorCode.NOT_EXIST_PRODUCT_ITEM));
+
+      //부모인 주문 도메인이 직접 주문 상품 생성해서 반환하도록 변경 (이 메서드 내에서 생성 완료될 주문 객체가 주문 자식 내에도 있어야 해서 직접 주문 엔티티 내에서 this로 주문자식 객체에 본인을 setting하기로 함)
+      OrdersItem ordersItem = orders.createOrdersItem(productItem, cartItem);
+      ordersItemList.add(ordersItem);
+    }
+
+    //3. order set (item setting)
+    orders = orders.createOrders(member,orders, ordersItemList); //수정함.. (빌더패턴으로 통일을 못했는데 통일 필요할 수도..)
+    ordersRepository.save(orders); //주문 key값 안 들어가서 도메인이 직접 객체들을 만들어서 반환하는 식으로 수정했음
+
+    //4. 장바구니 상품 삭제 (한꺼번에 장바구니 내 아이템을 모두 주문 들어갔기 때문에, 이용자의 장바구니 id를 key로 해서 한번에 장바구니 상품 삭제 처리)
+    Cart cart = cartRepository.findById(cartItemDetailList.get(0).getCartId())
+            .orElseThrow(() -> new OrderException(OrderErrorCode.OVER_QUANTITY));
+    cartService.deleteAllCartItem(cart.getCartId());
+  }
+
+
+}

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -47,18 +47,12 @@
         //수량 input value 변경 시, 상품 row 한개의 값 변경
         function changeProductQuantity(changeProductParam) {
 
-          let url = '/api/cart/update-quantity-req';
+          let url = '/api/cart/updateItemsQuantity';
 
           axios.put(url, changeProductParam).then(function(response) {
 
             response.data = response.data || {};
             response.data.responseResultHeader = response.data.responseResultHeader || {};
-
-            //fail (01.14 해당 컨트톨러 내에서의 잘못된 분기처리를 통한 응답값 내려주기를 수정하였으므로 이 라인을 주석 처리.)
-<!--            if (!response.data.responseResultHeader.result) {-->
-<!--              alert('내부 서버 오류로 인해 장바구니 상품 수량이 변경되지 않았습니다.');-->
-<!--              return false;-->
-<!--            }-->
 
             //success
             //전체 합계 금액 계산 call
@@ -120,13 +114,8 @@
           function(item) {
             item.querySelector('button[type=button]').addEventListener('click', function() {
 
-              let deleteProductParam = {
-                cartItemId: this.value
-              };
-
-              console.log('deleteparameter 확인');
-              console.log(deleteProductParam);
-              deleteProduct(deleteProductParam);
+              let cartItemId = this.value;
+              deleteProduct(cartItemId);
             })
           }
 
@@ -134,21 +123,16 @@
 
 
         //장바구니 상품 삭제 처리
-        function deleteProduct(deleteProductParam) {
+        function deleteProduct(cartItemId) {
 
-          let url = '/api/cart/delete-product-req';
+          let url = '/api/cart/deleteProduct/' + cartItemId;
           //delete -> config 내 data 속성으로 보내주어야 api에서 @RequestBody parameter 받을 수 있음
           //구조분해할당 ... -> config 중, data 속성만 든 것을 컨트롤러로 전송
-          axios.delete(url, {headers: {'Content-Type': `application/json`}, data: {...deleteProductParam}}).then(function(response) {
+          //{headers: {'Content-Type': `application/json`}, data: {...deleteProductParam}} 로 body에 전송했으나, @PathValiable 통해서 data 전송하기로 수정. (01.16)
+          axios.delete(url).then(function(response) {
 
             response.data = response.data || {};
             response.data.responseResultHeader = response.data.responseResultHeader || {};
-
-            //fail (01.14 해당 컨트톨러 내에서의 잘못된 분기처리를 통한 응답값 내려주기를 수정하였으므로 이 라인을 주석 처리.)
-<!--            if (!response.data.responseResultHeader.result) {-->
-<!--              alert('내부 서버 오류로 인해 장바구니 상품이 삭제되지 않았습니다.');-->
-<!--              return false;-->
-<!--            }-->
 
             //success
             //load page
@@ -170,7 +154,7 @@
 
         //구매하기 버튼 클릭 이벤트
         document.querySelector('#btn-purchase').addEventListener('click', function() {
-          location.href = '/order/from-cart';
+          location.href = '/order/cartItem';
         });
 
       }); //window.addEventListener

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -47,7 +47,7 @@
         //수량 input value 변경 시, 상품 row 한개의 값 변경
         function changeProductQuantity(changeProductParam) {
 
-          let url = '/api/cart/updateItemsQuantity';
+          let url = '/api/cart/cartItem';
 
           axios.put(url, changeProductParam).then(function(response) {
 
@@ -125,7 +125,7 @@
         //장바구니 상품 삭제 처리
         function deleteProduct(cartItemId) {
 
-          let url = '/api/cart/deleteProduct/' + cartItemId;
+          let url = '/api/cart/cartItem/' + cartItemId;
           //delete -> config 내 data 속성으로 보내주어야 api에서 @RequestBody parameter 받을 수 있음
           //구조분해할당 ... -> config 중, data 속성만 든 것을 컨트롤러로 전송
           //{headers: {'Content-Type': `application/json`}, data: {...deleteProductParam}} 로 body에 전송했으나, @PathValiable 통해서 data 전송하기로 수정. (01.16)

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -31,8 +31,9 @@
             item.querySelector('input[type=number]').addEventListener('change', function() {
 
               let changeProductParam = {
-                cartItemId: this.parentNode.querySelector('input[type=hidden]').value
+                cartItemId: this.parentNode.querySelector('.cart-item-id').value //input[type=hidden]
                 , quantity: this.value
+                , stock: this.parentNode.querySelector('.product-stock').value //product-stock
               };
 
               //장바구니 수량 update
@@ -271,7 +272,8 @@
               <div class="form-group quantity">
                 <label th:for="'quantity_' + ${cartItem.cartItemId}">수량</label>
                 <input th:value="${cartItem.quantity}" type="number" class="form-control" th:id="'quantity_' + ${cartItem.cartItemId}" th:name="'quantity_' + ${cartItem.cartItemId}" />
-                <input type="hidden" th:value="${cartItem.cartItemId}"> <!-- 장바구니 상품 Key value -->
+                <input type="hidden" th:value="${cartItem.cartItemId}" class="cart-item-id"> <!-- 장바구니 상품 Key value -->
+                <input type="hidden" th:value="${cartItem.stock}" class="product-stock"> <!-- 해당 상품의 재고  -->
               </div>
             </td>
             <td class="col-4">

--- a/src/main/resources/templates/cart/cart_item_list.html
+++ b/src/main/resources/templates/cart/cart_item_list.html
@@ -168,9 +168,10 @@
 
         }
 
-
-
-
+        //구매하기 버튼 클릭 이벤트
+        document.querySelector('#btn-purchase').addEventListener('click', function() {
+          location.href = '/order/from-cart';
+        });
 
       }); //window.addEventListener
 
@@ -311,7 +312,7 @@
             </h4>
           </div>
           <div class="col-3">
-            <button type="button" class="btn btn-info btn-block">구매하기</button>
+            <button type="button" class="btn btn-info btn-block" id="btn-purchase">구매하기</button>
           </div>
         </div>
       </div>

--- a/src/main/resources/templates/member/member_join.html
+++ b/src/main/resources/templates/member/member_join.html
@@ -75,6 +75,10 @@
         <input type="password" class="form-control" id="password" name="password" placeholder="비밀번호 입력">
       </div>
       <div class="mb-3">
+        <label for="phoneNumber" class="form-label">핸드폰번호</label>
+        <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" placeholder="핸드폰번호 입력">
+      </div>
+      <div class="mb-3">
         <label for="zipcode" class="form-label">우편번호</label>
         <input type="text" class="form-control" id="zipcode" name="zipcode" readonly placeholder="우편번호">
         <button onclick="execDaumPostcode()" type="button">우편번호 찾기</button>

--- a/src/main/resources/templates/order/order_from_cart.html
+++ b/src/main/resources/templates/order/order_from_cart.html
@@ -84,7 +84,7 @@
       //주문 생성 api 호출
       function callOrderCreateApi() {
 
-        let url = '/api/orderForCartItem';
+        let url = '/api/order/cartItem';
 
         axios.post(url).then(function(response) {
 

--- a/src/main/resources/templates/order/order_from_cart.html
+++ b/src/main/resources/templates/order/order_from_cart.html
@@ -18,13 +18,59 @@
   <th:block layout:fragment="script">
     <script th:inline="javascript">
 
-      window.addEventListener('DOMContentLoaded', function(){
+      window.addEventListener('DOMContentLoaded', function() {
 
-
-
-
+        //금액 setting
+        init();
 
       }); //window.addEventListener
+
+      async function init() {
+
+        let totalPrice = await calculateEachProduct(); //1. 총 금액 계산하기
+        await markTotalPrice(totalPrice); //2. 계산한 총 금액 바탕으로 배송비 더한 값 ui 출력
+      }
+
+      //각 상품마다의 개수 * 금액 계산
+      function calculateEachProduct() {
+
+        return new Promise(function(resolve, reject) {
+
+          let totalPrice = 0; //총 결제금액
+
+          document.querySelectorAll('.quantity').forEach(
+
+            function(item) {
+
+              let quantity = item.querySelector('span').innerHTML; //수량
+              let eachPrice = item.parentNode.nextElementSibling.querySelector('input[type=hidden]').value; //각각 1개 가격
+              let productPrice = quantity * eachPrice; //각 상품의 수량 곱한 가격
+
+              item.parentNode.nextElementSibling.querySelector('span').innerHTML = productPrice + '원';
+              totalPrice += productPrice;
+            }
+          );
+
+          resolve(totalPrice);
+        });
+
+      }
+
+      function markTotalPrice(totalPrice) {
+
+        return new Promise(function(resolve, reject) {
+
+          //배송비
+          let shippingFee = (totalPrice > 30000) ? 0 : 3000;
+
+          //최종 상품 금액 표시
+          document.querySelector('#total-product-price').innerHTML = totalPrice + '원';
+          document.querySelector('#shipping-fee').innerHTML = shippingFee;
+          document.querySelector('#total-payment').innerHTML = totalPrice + shippingFee;
+
+          resolve();
+        });
+      }
 
     </script>
   </th:block>
@@ -100,33 +146,34 @@
         <thead>
         <tr>
           <th colspan="3">
-            <span class="btn btn-light">배송정보</span>
+            <span class="btn btn-primary">배송정보</span>
           </th>
         </tr>
         </thead>
         <tbody>
           <tr>
             <th>받는 사람</th>
-            <td>김소리</td>
+            <td th:text="${shippingAddress.name}"></td>
           </tr>
           <tr>
             <th>휴대전화</th>
-            <td>01047176208</td>
+            <td th:text="${shippingAddress.phoneNumber}"></td>
           </tr>
           <tr>
             <th>배송주소</th>
-            <td>서울특별시 서울역</td>
+            <td>
+              <span th:text="${shippingAddress.address}"></span> <span th:text="${shippingAddress.addressDetail}"></span>
+            </td>
           </tr>
         </tbody>
       </table>
-      <hr/>
 
       <!-- 주문예정상품 - 장바구니 목록 -> 주문결제 page -->
       <table class="table table-borderless order-info" id="cart-item-list" style="margin-bottom: 20px;"> <!-- container-md -->
-        <thead>
+        <thead class="thead-light">
           <tr>
             <th colspan="3">
-              <span class="btn btn-light">주문상품</span>
+              주문상품
             </th>
           </tr>
         </thead>
@@ -153,8 +200,9 @@
             <td class="col-2">
               <!-- quantity  -->
               <div class="form-group quantity">
-                <label th:for="'quantity_' + ${cartItem.cartItemId}">수량</label>
-                <input th:value="${cartItem.quantity}" type="number" class="form-control" th:id="'quantity_' + ${cartItem.cartItemId}" th:name="'quantity_' + ${cartItem.cartItemId}" />
+                <h5>
+                  수량 <span th:text="${cartItem.quantity}"></span> 개
+                </h5>
                 <input type="hidden" th:value="${cartItem.cartItemId}"> <!-- 장바구니 상품 Key value -->
               </div>
             </td>
@@ -162,7 +210,8 @@
               <!-- price -->
               <div>
                 <h2 class="price">
-                  <span th:text="${cartItem.price}" class="badge badge-pill badge-light"></span>원
+                  <span th:text="${cartItem.price}" class="badge badge-pill badge-light"></span>
+                  <input type="hidden" th:value="${cartItem.price}">
                 </h2>
               </div>
             </td>
@@ -182,15 +231,15 @@
         <tbody>
         <tr>
           <th>총 상품 금액</th>
-          <td>19000원</td>
+          <td id="total-product-price"></td>
         </tr>
         <tr>
           <th>배송비</th>
-          <td>+3000원</td>
+          <td>+<span id="shipping-fee"></span>원</td>
         </tr>
         <tr>
           <th>총 결제금액</th>
-          <td><h3><span class="badge badge-pill badge-warning">22000원</span></h3></td>
+          <td><h3><span class="badge badge-pill badge-warning" id="total-payment"></span>원</h3></td>
         </tr>
         </tbody>
       </table>

--- a/src/main/resources/templates/order/order_from_cart.html
+++ b/src/main/resources/templates/order/order_from_cart.html
@@ -23,8 +23,16 @@
         //금액 setting
         init();
 
+        //결제하기 버튼 클릭 이벤트
+        document.querySelector('#btn-order').addEventListener('click', function() {
+          //주문 생성 api call
+          callOrderCreateApi();
+        });
+
+
       }); //window.addEventListener
 
+      //화면 로딩 시, 필요한 금액 정보 setting
       async function init() {
 
         let totalPrice = await calculateEachProduct(); //1. 총 금액 계산하기
@@ -56,6 +64,7 @@
 
       }
 
+      //각 상품의 금액 합한 총 주문 금액 계산
       function markTotalPrice(totalPrice) {
 
         return new Promise(function(resolve, reject) {
@@ -70,6 +79,33 @@
 
           resolve();
         });
+      }
+
+      //주문 생성 api 호출
+      function callOrderCreateApi() {
+
+        let url = '/api/order/from-cart';
+
+        axios.post(url).then(function(response) {
+
+          response.data = response.data || {};
+          response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+          //success
+          //전체 합계 금액 계산 call
+          alert('결제가 완료되었습니다.');
+
+        }).catch(function(error) {
+
+          if (error.response) {
+            //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
+            console.log(error.response.data);
+            alert(error.response.data.errorMessage);
+          }
+
+          console.log(error);
+        });
+
       }
 
     </script>
@@ -255,7 +291,7 @@
           <span>위 주문 내용을 확인하였으며 결제하겠습니다.</span>
         </div>
         <div class="row">
-          <button type="button" class="btn btn-info btn-block">결제하기</button>
+          <button type="button" class="btn btn-info btn-block" id="btn-order">결제하기</button>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/order/order_from_cart.html
+++ b/src/main/resources/templates/order/order_from_cart.html
@@ -84,7 +84,7 @@
       //주문 생성 api 호출
       function callOrderCreateApi() {
 
-        let url = '/api/order/from-cart';
+        let url = '/api/orderForCartItem';
 
         axios.post(url).then(function(response) {
 

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -45,7 +45,7 @@
             return false;
           }
 
-          let url = '/api/cart/addCartItem';
+          let url = '/api/cart/cartItem';
           let quantity = quantityInput.value;
 
           let parameter = {

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -45,7 +45,7 @@
             return false;
           }
 
-          let url = '/api/cart/add-req';
+          let url = '/api/cart/addCartItem';
           let quantity = quantityInput.value;
 
           let parameter = {
@@ -57,12 +57,6 @@
 
             response.data = response.data || {};
             response.data.responseResultHeader = response.data.responseResultHeader || {};
-
-            //fail (01.14 해당 컨트톨러 내에서의 잘못된 분기처리를 통한 응답값 내려주기를 수정하였으므로 이 라인을 주석 처리.)
-<!--            if (!response.data.responseResultHeader.result) {-->
-<!--              alert('내부 서버 오류로 인해 장바구니에 상품을 담을 수 없습니다.');-->
-<!--              return false;-->
-<!--            }-->
 
             //success
             alert('장바구니에 해당 상품을 담았습니다.');


### PR DESCRIPTION
:white_check_mark: Changes

- 기존의 장바구니 API URL을 Rest API 가이드에 맞게끔 확인하여 url 수정 및 화면 api 호출 라인 수정하였습니다
- 장바구니 상품 담기 or 수량 변경 시, 해당 상품의 재고를 초과할 시, 불가능하도록 예외 처리 추가하였습니다
- 요구사항에 주문을 하는 방법을 2가지로 했었는데
 (상품 상세 페이지에서 바로주문 버튼 or 장바구니 상품들 묶어서 주문)
우선 장바구니 상품들 묶어서 주문 기능이 가능한 API를 추가하였습니다. 

<br>

:heavy_plus_sign: Related Details
- 아래의 ERD 내 주문, 주문_상품에 대한 create 작업을 하였습니다.
![주문도메인작업](https://user-images.githubusercontent.com/65488155/212633143-45d31762-4d26-4352-8563-07411eb0e491.jpg)
- 주문의 경우, 2가지 방법이 있는데 우선 장바구니에서 구매하기 버튼 클릭 -> 장바구니 data 반영된 주문서 확인하여 결제버튼 클릭 (실제 결제 기능을 구현하진 않았습니다!)의 시나리오에 대해서 구현하였습니다.

1)  장바구니 구매 버튼 클릭
![수정및추가부분](https://user-images.githubusercontent.com/65488155/212634105-478194c8-6170-4b47-93c5-799dde9f773d.jpg)

2) 주문확인서 내 결제하기 버튼 클릭 (결제 기능 없으나 통상적인 ui 확인 후 적용)
![장바구니접근주문API호출](https://user-images.githubusercontent.com/65488155/212634259-efcda1a6-8602-4cdc-bcda-d36b8dd27925.jpg)
3) 주문 data 주문 접수 상태로 하여 insert & 및 주문 상품 data insert

이렇게 주문하기 시나리오 1개를 구현했습니다.

<br>

:pray: To Reviewers
- 주문하기 관련 data는 모두 직접 DB tool로 쿼리 작성으로 확인하여 data 꼬임 없이 key 값 서로 정상적으로 들어갔음을 확인했습니다. 그러나, 주문 기능 관련해서 알아두어야 할 JPA 기초 지식들이 아직 부족해서 해당 메서드가 기능은 동작하나 정상적인 흐름인지는 파악중입니다.. 
- 처음 주문 메서드 작성 시, 메서드 안에서 모두 나열하는 식으로 data 관련한 코드를 추가했는데 코드가 깔끔하지 않아 찾아본 결과, JPA는 해당 방식(트랜젝션 스크립트 패턴)뿐 아니라 도메인 모델 패턴을 지원한단 것을 알았습니다. 기존 스프링에서 프록시 패턴으로 트랜젝션 어노테이션이 붙은 데에 대해 트랜젝션 처리 들어가는 것 외에도 JPA를 적용하면 생각해볼 수 있는 이슈여서 학습이 필요함을 알았습니다.
- 참고 학습링크
https://velog.io/@joajoa/%EC%8A%A4%ED%94%84%EB%A7%81-%EB%B6%80%ED%8A%B8%EC%99%80-JPA-%ED%99%9C%EC%9A%A91-%EC%A3%BC%EB%AC%B8-%EB%8F%84%EB%A9%94%EC%9D%B8-%EA%B0%9C%EB%B0%9C-2-7upp6evz
