### PR TITLE
고객 주문 내역, 주문 상세 내역, 주문취소(상태 변경) 기능 추가

### DIFF
--- a/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
+++ b/src/main/java/com/shoptest/catmart/common/exception/type/OrderErrorCode.java
@@ -11,7 +11,9 @@ public enum OrderErrorCode {
   OVER_QUANTITY("주문하신 상품의 수량이 현재 상품 재고량을 초과합니다."),
   OUT_OF_STOCK("주문하신 상품은 현재 품절 상태입니다."),
   NOT_EXIST_PRODUCT_ITEM("주문하신 상품은 존재하지 않는 상품입니다."),
-  NOT_EXIST_CART_ITEM("주문할 수 있는 장바구니 상품을 담아주세요.");
+  NOT_EXIST_CART_ITEM("주문할 수 있는 장바구니 상품을 담아주세요."),
+  NOT_EXIST_ORDER("해당 주문은 존재하지 않는 내역입니다."),
+  NOT_POSSIBLE_CANCEL("해당 주문은 현재 취소할 수 없습니다. 주문 접수 상태의 주문만 취소가 가능합니다.");
 
   private final String description;
 }

--- a/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
@@ -7,7 +7,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +25,16 @@ public class ApiOrderController {
 
     String email = principal.getName();
     orderService.createOrder(email);
+
+    ResponseResult responseResult = new ResponseResult(true);
+    return ResponseEntity.ok().body(responseResult);
+  }
+
+  @PutMapping("/api/order/orderItem/{ordersId}")
+  public ResponseEntity<?> cancelOrderForMember(Model model, Principal principal, @PathVariable Long ordersId) {
+
+    String email = principal.getName();
+    orderService.cancelOrder(email, ordersId);
 
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);

--- a/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
@@ -36,6 +37,16 @@ public class OrderController {
     model.addAttribute("ordersHistoryList", orderService.selectOrdersHistoryList(email));
 
     return "/order/order_history_list";
+  }
+
+  @GetMapping("/history/detail/{ordersId}")
+  public String odderHistoryDetail(Model model, Principal principal, @PathVariable Long ordersId) {
+
+    String email = principal.getName();
+    model.addAttribute("shippingAddress", memberService.selectMemberAddress(email)); //배송지 (원래는 배송 관련 내용만 따로 담은 table 필요..)
+    model.addAttribute("ordersHistoryDetailList", orderService.selectOrdersHistoryDetailList(email, ordersId)); //주문 내 상세 주문정보 list
+
+    return "/order/order_history_detail";
   }
 
 }

--- a/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
@@ -2,6 +2,7 @@ package com.shoptest.catmart.order.controller;
 
 import com.shoptest.catmart.cart.service.CartService;
 import com.shoptest.catmart.member.service.MemberService;
+import com.shoptest.catmart.order.service.OrderService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -16,6 +17,7 @@ public class OrderController {
 
   private final CartService cartService;
   private final MemberService memberService;
+  private final OrderService orderService;
 
   @GetMapping("/cartItem")
   public String orderFromCart(Model model, Principal principal) {
@@ -25,6 +27,15 @@ public class OrderController {
     model.addAttribute("cartItemList", cartService.selectCartItemDetailList(email)); //장바구니에 담은 상품 목록
 
     return "/order/order_from_cart";
+  }
+
+  @GetMapping("/history")
+  public String orderHistory(Model model, Principal principal) {
+
+    String email = principal.getName();
+    model.addAttribute("ordersHistoryList", orderService.selectOrdersHistoryList(email));
+
+    return "/order/order_history_list";
   }
 
 }

--- a/src/main/java/com/shoptest/catmart/order/domain/Orders.java
+++ b/src/main/java/com/shoptest/catmart/order/domain/Orders.java
@@ -91,5 +91,11 @@ public class Orders {
     return orders;
   }
 
+  /* 주문 취소하기 */
+  public Orders cancelOrders(Orders orders) {
+    orders.setOrdersStatus(OrderStatus.CANCEL_ORDER);
+    return orders;
+  }
+
 
 }

--- a/src/main/java/com/shoptest/catmart/order/dto/OrdersHistoryDetailDto.java
+++ b/src/main/java/com/shoptest/catmart/order/dto/OrdersHistoryDetailDto.java
@@ -1,0 +1,51 @@
+package com.shoptest.catmart.order.dto;
+
+import com.shoptest.catmart.order.type.OrderStatus;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * front 주문 내역 - 주문 내역 상세 목록 고객 조회용 DTO
+ * */
+@Getter
+@Setter
+public class OrdersHistoryDetailDto {
+
+  /* 주문 id */
+  private Long ordersId;
+
+  /* 주문 일자 */
+  private LocalDateTime ordersDate;
+
+  /* 주문 상태 */
+  private OrderStatus ordersStatus;
+
+  /* 회원 id */
+  private Long memberId;
+
+  /* 주문 상품 결제 금액 */
+  private int orderPrice;
+
+  /* 상품 id */
+  private Long productItemId;
+
+  /* 주문상품 id */
+  private Long ordersItemId;
+
+  /* 주문상품 수량 */
+  private int quantity;
+
+  /* 상품명 */
+  private String itemName;
+
+  /* 출력용 url img path */
+  private String urlImgPath;
+
+  public String getOrdersDate() {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+    return ordersDate != null ? ordersDate.format(formatter) : "";
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/order/dto/OrdersHistoryDto.java
+++ b/src/main/java/com/shoptest/catmart/order/dto/OrdersHistoryDto.java
@@ -1,0 +1,58 @@
+package com.shoptest.catmart.order.dto;
+
+import com.shoptest.catmart.order.type.OrderStatus;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+/**
+ * front 주문 내역 - 주문 내역 목록 고객 조회용 DTO
+ * */
+@Getter
+@Setter
+public class OrdersHistoryDto {
+
+  /* 주문 id */
+  private Long ordersId;
+
+  /* 주문 상품 종류 개수 */
+  private int kindsCount;
+
+  /* 주문 일자 */
+  private LocalDateTime ordersDate;
+
+  /* 주문 상태 */
+  private OrderStatus ordersStatus;
+
+  /* 회원 id */
+  private Long memberId;
+
+  /* 총 상품 주문 금액 */
+  private Long totalOrderPrice;
+
+  /* 총 상품 주문 금액에 배송비 더해진 금액 */
+  private Long shippingFeeAddedPrice;
+
+  /* 상품 id -> 해당 주문상품 중 상품 id가 가장 적은 것 */
+  private Long productItemId;
+
+  /* 해당 주문의 주문상품 id 모두 문자열로 더한 것 */
+  private String ordersItemIdList;
+
+  /* 주문상품의 총 수량 개수 */
+  private int sumQuantity;
+
+  /* 주문 내역 출력용 상품이름 정보 */
+  private String itemNameInfo;
+
+  /* 주문 내역 출력용 상품이름에 대한 출력용 url img path */
+  private String urlImgPath;
+
+  public String getOrdersDate() {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+    return ordersDate != null ? ordersDate.format(formatter) : "";
+  }
+
+}

--- a/src/main/java/com/shoptest/catmart/order/mapper/OrdersMapper.java
+++ b/src/main/java/com/shoptest/catmart/order/mapper/OrdersMapper.java
@@ -1,5 +1,6 @@
 package com.shoptest.catmart.order.mapper;
 
+import com.shoptest.catmart.order.dto.OrdersHistoryDetailDto;
 import com.shoptest.catmart.order.dto.OrdersHistoryDto;
 import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
@@ -9,5 +10,8 @@ public interface OrdersMapper {
 
   /* 고객용 - 주문내역 목록 조회 */
   List<OrdersHistoryDto> selectOrdersHistoryList(Long memberId);
+
+  /* 고객용 - 주문내역 내 주문 상세조회 */
+  List<OrdersHistoryDetailDto> selectOrdersHistoryDetailList(Long memberId, Long ordersId);
 
 }

--- a/src/main/java/com/shoptest/catmart/order/mapper/OrdersMapper.java
+++ b/src/main/java/com/shoptest/catmart/order/mapper/OrdersMapper.java
@@ -1,0 +1,13 @@
+package com.shoptest.catmart.order.mapper;
+
+import com.shoptest.catmart.order.dto.OrdersHistoryDto;
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface OrdersMapper {
+
+  /* 고객용 - 주문내역 목록 조회 */
+  List<OrdersHistoryDto> selectOrdersHistoryList(Long memberId);
+
+}

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -15,4 +15,7 @@ public interface OrderService {
   /* 고객 - 주문하기 목록 내 주문 단건 상세 조회 */
   List<OrdersHistoryDetailDto> selectOrdersHistoryDetailList(String email, Long ordersId);
 
+  /* 고객 - 주문하기 목록 내 주문 취소하기(상태 변경) */
+  void cancelOrder(String email, Long ordersId);
+
 }

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -1,5 +1,6 @@
 package com.shoptest.catmart.order.service;
 
+import com.shoptest.catmart.order.dto.OrdersHistoryDetailDto;
 import com.shoptest.catmart.order.dto.OrdersHistoryDto;
 import java.util.List;
 
@@ -10,5 +11,8 @@ public interface OrderService {
 
   /* 고객 - 주문하기 목록 조회 */
   List<OrdersHistoryDto> selectOrdersHistoryList(String email);
+
+  /* 고객 - 주문하기 목록 내 주문 단건 상세 조회 */
+  List<OrdersHistoryDetailDto> selectOrdersHistoryDetailList(String email, Long ordersId);
 
 }

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -1,8 +1,14 @@
 package com.shoptest.catmart.order.service;
 
+import com.shoptest.catmart.order.dto.OrdersHistoryDto;
+import java.util.List;
+
 public interface OrderService {
 
   /* 고객 - 주문하기(장바구니에서 접근) */
   void createOrder(String email);
+
+  /* 고객 - 주문하기 목록 조회 */
+  List<OrdersHistoryDto> selectOrdersHistoryList(String email);
 
 }

--- a/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
@@ -10,6 +10,8 @@ import com.shoptest.catmart.member.domain.Member;
 import com.shoptest.catmart.member.repository.MemberRepository;
 import com.shoptest.catmart.order.domain.Orders;
 import com.shoptest.catmart.order.domain.OrdersItem;
+import com.shoptest.catmart.order.dto.OrdersHistoryDto;
+import com.shoptest.catmart.order.mapper.OrdersMapper;
 import com.shoptest.catmart.order.repository.OrdersRepository;
 import com.shoptest.catmart.order.service.OrderService;
 import com.shoptest.catmart.product.domain.ProductItem;
@@ -30,6 +32,7 @@ public class OrderServiceImpl implements OrderService {
   private final CartService cartService;
   private final CartRepository cartRepository;
   private final OrdersRepository ordersRepository;
+  private final OrdersMapper ordersMapper;
 
 
   @Transactional
@@ -78,6 +81,14 @@ public class OrderServiceImpl implements OrderService {
     Cart cart = cartRepository.findById(cartItemDetailList.get(0).getCartId())
             .orElseThrow(() -> new OrderException(OrderErrorCode.OVER_QUANTITY));
     cartService.deleteAllCartItem(cart.getCartId());
+  }
+
+  @Override
+  public List<OrdersHistoryDto> selectOrdersHistoryList(String email) {
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new OrderException(OrderErrorCode.USER_EMAIL_NOT_EXIST));
+    return ordersMapper.selectOrdersHistoryList(member.getMemberId());
   }
 
 

--- a/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/order/service/impl/OrderServiceImpl.java
@@ -10,6 +10,7 @@ import com.shoptest.catmart.member.domain.Member;
 import com.shoptest.catmart.member.repository.MemberRepository;
 import com.shoptest.catmart.order.domain.Orders;
 import com.shoptest.catmart.order.domain.OrdersItem;
+import com.shoptest.catmart.order.dto.OrdersHistoryDetailDto;
 import com.shoptest.catmart.order.dto.OrdersHistoryDto;
 import com.shoptest.catmart.order.mapper.OrdersMapper;
 import com.shoptest.catmart.order.repository.OrdersRepository;
@@ -40,8 +41,7 @@ public class OrderServiceImpl implements OrderService {
   public void createOrder(String email) {
 
     //1. member check
-    Member member = memberRepository.findByEmail(email)
-        .orElseThrow(() -> new OrderException(OrderErrorCode.USER_EMAIL_NOT_EXIST));
+    Member member = getMember(email);
 
     //2. to be orders_item -> check
     // (1) 해당 이용자 장바구니_상품 및 해당 상품 정보 select -> (2) 현재 상품 재고 및 상태 체크 -> (3) 주문_상품으로 변환하기 4) 주문에 주문 상품 set
@@ -86,10 +86,22 @@ public class OrderServiceImpl implements OrderService {
   @Override
   public List<OrdersHistoryDto> selectOrdersHistoryList(String email) {
 
-    Member member = memberRepository.findByEmail(email)
-        .orElseThrow(() -> new OrderException(OrderErrorCode.USER_EMAIL_NOT_EXIST));
+    Member member = getMember(email);
     return ordersMapper.selectOrdersHistoryList(member.getMemberId());
   }
 
+  @Override
+  public List<OrdersHistoryDetailDto> selectOrdersHistoryDetailList(String email, Long ordersId) {
+
+    Member member = getMember(email);
+    return ordersMapper.selectOrdersHistoryDetailList(member.getMemberId(), ordersId);
+  }
+
+  private Member getMember(String email) {
+
+    Member member = memberRepository.findByEmail(email)
+        .orElseThrow(() -> new OrderException(OrderErrorCode.USER_EMAIL_NOT_EXIST));
+    return member;
+  }
 
 }

--- a/src/main/resources/mybatis/order/OrdersMapper.xml
+++ b/src/main/resources/mybatis/order/OrdersMapper.xml
@@ -57,5 +57,49 @@
     ORDER BY T1.ORDERS_DATE DESC
   </select>
 
+  <select id="selectOrdersHistoryDetailList" resultType="com.shoptest.catmart.order.dto.OrdersHistoryDetailDto">
+    SELECT
+      T1.ORDERS_ID
+      , T1.ORDERS_DATE
+      , T1.ORDERS_STATUS
+      , T1.MEMBER_ID
+      , T1.ORDER_PRICE
+      , T1.PRODUCT_ITEM_ID
+      , T1.ORDERS_ITEM_ID
+      , T1.QUANTITY
+      , T2.ITEM_NAME
+      , T2.ITEM_STATUS
+      , T2.ITEM_SUBJECT
+      , T2.URL_IMG_PATH
+    FROM
+    (
+      SELECT
+        A.ORDERS_ID
+        , A.ORDERS_DATE
+        , A.ORDERS_STATUS
+        , A.MEMBER_ID
+        , B.ORDER_PRICE
+        , B.PRODUCT_ITEM_ID
+        , B.ORDERS_ITEM_ID
+        , B.QUANTITY
+      FROM ORDERS A
+      INNER JOIN ORDERS_ITEM B
+      ON A.ORDERS_ID = B.ORDERS_ID
+      AND A.MEMBER_ID = #{memberId}
+      AND A.ORDERS_ID = #{ordersId}
+    ) T1
+    INNER JOIN (
+      SELECT
+        C.PRODUCT_ITEM_ID
+        , C.ITEM_NAME
+        , C.ITEM_STATUS
+        , C.ITEM_SUBJECT
+        , D.URL_IMG_PATH
+      FROM PRODUCT_ITEM C
+      INNER JOIN ITEM_IMG D
+      ON C.PRODUCT_ITEM_ID = D.PRODUCT_ITEM_ID
+    ) T2
+    ON T1.PRODUCT_ITEM_ID = T2.PRODUCT_ITEM_ID
+  </select>
 
 </mapper>

--- a/src/main/resources/mybatis/order/OrdersMapper.xml
+++ b/src/main/resources/mybatis/order/OrdersMapper.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.shoptest.catmart.order.mapper.OrdersMapper">
+
+  <select id="selectOrdersHistoryList" resultType="com.shoptest.catmart.order.dto.OrdersHistoryDto">
+    SELECT
+      T1.ORDERS_ID
+      , COUNT(T1.ORDERS_ID) AS KINDS_COUNT
+      , T1.ORDERS_DATE
+      , T1.ORDERS_STATUS
+      , T1.MEMBER_ID
+      , SUM(T1.ORDER_PRICE) AS TOTAL_ORDER_PRICE
+      , CASE
+          WHEN SUM(T1.ORDER_PRICE) <![CDATA[ > ]]> 30000 THEN SUM(T1.ORDER_PRICE)
+          WHEN SUM(T1.ORDER_PRICE) <![CDATA[ <= ]]> 30000 THEN SUM(T1.ORDER_PRICE) + 3000
+        END AS SHIPPING_FEE_ADDED_PRICE
+      , T1.PRODUCT_ITEM_ID
+      , GROUP_CONCAT(T1.ORDERS_ITEM_ID) AS ORDERS_ITEM_ID_LIST
+      , SUM(T1.QUANTITY) AS SUN_QUANTITY
+      , CASE
+          WHEN COUNT(T1.ORDERS_ID) = 1 THEN T2.ITEM_NAME
+          WHEN COUNT(T1.ORDERS_ID) <![CDATA[ > ]]> 1 THEN CONCAT(T2.ITEM_NAME, ' 외 ', cast(COUNT(T1.ORDERS_ID) AS char), '건')
+        END AS ITEM_NAME_INFO
+      , T2.ITEM_STATUS
+      , T2.ITEM_SUBJECT
+      , T2.URL_IMG_PATH
+    FROM (
+      SELECT
+        A.ORDERS_ID
+        , A.ORDERS_DATE
+        , A.ORDERS_STATUS
+        , A.MEMBER_ID
+        , B.ORDER_PRICE
+        , B.PRODUCT_ITEM_ID
+        , B.ORDERS_ITEM_ID
+        , B.QUANTITY
+      FROM ORDERS A
+      INNER JOIN ORDERS_ITEM B
+      ON A.ORDERS_ID = B.ORDERS_ID
+      AND A.MEMBER_ID = #{memberId}
+    ) T1
+    INNER JOIN (
+      SELECT
+        C.PRODUCT_ITEM_ID
+        , C.ITEM_NAME
+        , C.ITEM_STATUS
+        , C.ITEM_SUBJECT
+        , D.URL_IMG_PATH
+      FROM PRODUCT_ITEM C
+      INNER JOIN ITEM_IMG D
+      ON C.PRODUCT_ITEM_ID = D.PRODUCT_ITEM_ID
+    ) T2
+    ON T1.PRODUCT_ITEM_ID = T2.PRODUCT_ITEM_ID
+    GROUP BY T1.ORDERS_ID
+    ORDER BY T1.ORDERS_DATE DESC
+  </select>
+
+
+</mapper>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -18,7 +18,7 @@
           <div class="navbar-nav">
             <a class="nav-link active" aria-current="page" href="/main">Main</a>
             <a class="nav-link" href="/product/list">전체 상품</a>
-            <a sec:authorize="isAuthenticated()" class="nav-link" href="#">내 주문내역</a>
+            <a sec:authorize="isAuthenticated()" class="nav-link" href="/order/history">내 주문내역</a>
             <a sec:authorize="isAuthenticated()" class="nav-link" href="/cart/list">장바구니</a>
             <a sec:authorize="hasAnyAuthority('ROLE_ADMIN_SELLER')" class="nav-link" href="/admin/product/list.do">상품 관리</a>
             <a sec:authorize="hasAnyAuthority('ROLE_ADMIN_SELLER')" class="nav-link" href="/admin/category/add.do">카테고리 관리</a>

--- a/src/main/resources/templates/order/order_history_detail.html
+++ b/src/main/resources/templates/order/order_history_detail.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+  <!-- axios cdn -->
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+
+  <th:block layout:fragment="script">
+    <script th:inline="javascript">
+
+      window.addEventListener('DOMContentLoaded', function() {
+
+        init();
+
+      }); //window.addEventListener
+
+      //금액 정보 setting
+      async function init() {
+
+        let totalPrice = await calculateSum(); //1. 각 계산값 더한 수 구하기
+        await markPriceInfo(totalPrice); //2. 값에 따른 필드값 html 출력하기
+      }
+
+      function calculateSum() {
+
+        return new Promise(function(resolve, reject) {
+
+          let totalPrice = 0; //총 결제 금액
+
+          document.querySelectorAll('.price').forEach(
+
+            function(item) {
+              let eachPrice = Number(item.querySelector('input[type=hidden]').value);
+              totalPrice += eachPrice;
+            }
+          );
+          resolve(totalPrice);
+        });
+      }
+
+      function markPriceInfo(totalPrice) {
+
+        return new Promise(function(resolve, reject) {
+
+          //배송비
+          let shippingFee = (totalPrice > 30000) ? 0 : 3000;
+
+          //최종 상품 금액 표시
+          document.querySelector('#total-product-price').innerHTML = totalPrice + '원';
+          document.querySelector('#shipping-fee').innerHTML = shippingFee;
+          document.querySelector('#total-payment').innerHTML = totalPrice + shippingFee;
+          resolve();
+        });
+      }
+
+    </script>
+  </th:block>
+
+  <th:block layout:fragment="css">
+    <style>
+
+      html {
+        position: relative;
+        min-height: 100%;
+        margin: 0;
+      }
+
+      body {
+        min-height: 100%;
+      }
+
+      .footer {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        padding: 15px 0;
+        text-align: center;
+      }
+
+      .header {
+        margin-bottom: 20px;
+
+      }
+
+      .content {
+        margin-bottom: 100px;
+        margin-top: 50px;
+        margin-left: 150px;
+        margin-right: 150px;
+      }
+
+      #sum-info-tab {
+        margin-top: 18px;
+      }
+
+      .order-info {
+        margin-bottom: 13px;
+      }
+
+
+    </style>
+  </th:block>
+
+</head>
+<body>
+
+  <div th:replace="fragments/header::header"></div>
+
+  <div class="content">
+
+    <!-- category info bar -->
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">
+          내 주문 > <span class="badge badge-primary">상세 주문 내역</span>
+        </li>
+      </ol>
+    </nav>
+
+    <!-- product detail area -->
+    <div class="container"> <!-- container-md-->
+
+      <!-- shipping-info -->
+      <table class="table table-borderless" style="margin-bottom: 20px;">
+        <thead class="thead-light">
+        <tr>
+          <th colspan="3">
+            배송정보
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>받는 사람</th>
+            <td th:text="${shippingAddress.name}"></td>
+          </tr>
+          <tr>
+            <th>휴대전화</th>
+            <td th:text="${shippingAddress.phoneNumber}"></td>
+          </tr>
+          <tr>
+            <th>배송주소</th>
+            <td>
+              <span th:text="${shippingAddress.address}"></span> <span th:text="${shippingAddress.addressDetail}"></span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- Payment Area -->
+      <table class="table table-borderless order-info" style="margin-bottom: 20px;">
+        <thead class="thead-light">
+        <tr>
+          <th colspan="3">
+            최종 결제금액
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th>총 상품 금액</th>
+          <td id="total-product-price"></td>
+        </tr>
+        <tr>
+          <th>배송비</th>
+          <td>+<span id="shipping-fee"></span>원</td>
+        </tr>
+        <tr>
+          <th>총 결제금액</th>
+          <td><h3><span class="badge badge-pill badge-warning" id="total-payment"></span>원</h3></td>
+        </tr>
+        </tbody>
+      </table>
+
+      <!-- Order Item Area -->
+      <table class="table table-borderless order-info" id="cart-item-list" style="margin-bottom: 20px;"> <!-- container-md -->
+        <thead class="thead-light">
+        <tr>
+          <th colspan="3">
+            주문상품
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="ordersHistoryDetail, i : ${ordersHistoryDetailList}" class="cart-item">
+          <td class="col-7">
+            <!-- img -->
+            <div class="border-0 card mb-3" style="max-width: 300px;">
+              <div class="row no-gutters">
+                <div class="col-md-4">
+                  <img th:src="${ordersHistoryDetail.urlImgPath}" class="card-img" alt="...">
+                </div>
+                <div class="col-md-8">
+                  <div class="card-body">
+                    <h5 th:text="${ordersHistoryDetail.itemName}" class="card-title"></h5>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+          <td class="col-2">
+            <!-- quantity  -->
+            <div class="form-group quantity">
+              <h5>
+                수량 <span th:text="${ordersHistoryDetail.quantity}"></span> 개
+              </h5>
+            </div>
+          </td>
+          <td class="col-3">
+            <!-- price -->
+            <div>
+              <h2 class="price">
+                <span th:text="${ordersHistoryDetail.orderPrice}" class="badge badge-pill badge-light"></span>
+                <input type="hidden" th:value="${ordersHistoryDetail.orderPrice}" />
+              </h2>
+            </div>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+
+  </div>
+
+  <div th:replace="fragments/footer::footer"></div>
+
+</body>
+</html>

--- a/src/main/resources/templates/order/order_history_list.html
+++ b/src/main/resources/templates/order/order_history_list.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+  <!-- axios cdn -->
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+
+  <th:block layout:fragment="script">
+    <script th:inline="javascript">
+
+      window.addEventListener('DOMContentLoaded', function(){
+
+
+      }); //window.addEventListener
+
+    </script>
+  </th:block>
+
+  <th:block layout:fragment="css">
+    <style>
+
+      html {
+        position: relative;
+        min-height: 100%;
+        margin: 0;
+      }
+
+      body {
+        min-height: 100%;
+      }
+
+      .footer {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        padding: 15px 0;
+        text-align: center;
+      }
+
+      .header {
+        margin-bottom: 20px;
+
+      }
+
+      .content {
+        margin-bottom: 100px;
+        margin-top: 50px;
+        margin-left: 150px;
+        margin-right: 150px;
+      }
+
+      #sum-info-tab {
+        margin-top: 18px;
+      }
+
+
+    </style>
+  </th:block>
+
+</head>
+<body>
+
+  <div th:replace="fragments/header::header"></div>
+
+  <div class="content">
+
+    <!-- category info bar -->
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">
+          내 주문
+        </li>
+      </ol>
+    </nav>
+
+    <!-- product detail area -->
+    <div class="d-flex justify-content-center">
+
+      <table class="container-md table table-bordered" id="cart-item-list">
+        <thead>
+          <tr>
+            <th colspan="5">
+              주문 내역
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr th:each="ordersHistory, i : ${ordersHistoryList}" class="cart-item">
+            <td class="col-4">
+              <!-- img -->
+              <div class="border-0 card mb-3" style="max-width: 300px;">
+                <div class="row no-gutters">
+                  <div class="col-md-4">
+                    <img th:src="${ordersHistory.urlImgPath}" class="card-img" alt="...">
+                  </div>
+                  <div class="col-md-8">
+                    <div class="card-body">
+                      <h5 th:text="${ordersHistory.itemNameInfo}" class="card-title"></h5>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="col-2">
+              <!-- ordersDate  -->
+              <div class="form-group">
+                <span th:text="${ordersHistory.getOrdersDate}"></span>
+              </div>
+            </td>
+            <td class="col-3">
+              <!-- price -->
+              <div>
+                <h2 class="price">
+                  <!-- 배송비 포함한 결제금액 출력 -->
+                  <span th:text="${ordersHistory.shippingFeeAddedPrice}" class="badge badge-pill badge-light"></span>원
+                </h2>
+              </div>
+            </td>
+            <td class="col-1">
+              <p th:if="${#strings.equals('TAKE_ORDER', ordersHistory.ordersStatus)}"> <!--'TAKE_ORDER'  'CANCEL_ORDER' 'PAY_FOR_ORDER' -->
+                <span class="badge badge-pill badge-warning">주문 접수</span> <!--th:text="${ordersHistory.ordersStatus}" -->
+              </p>
+              <p th:if="${#strings.equals('CANCEL_ORDER', ordersHistory.ordersStatus)}">
+                <span class="badge badge-pill badge-light">주문 취소</span> <!--th:text="${ordersHistory.ordersStatus}" -->
+              </p>
+              <p th:if="${#strings.equals('PAY_FOR_ORDER', ordersHistory.ordersStatus)}">
+                <span class="badge badge-pill badge-success">결제 완료 </span> <!--th:text="${ordersHistory.ordersStatus}" -->
+              </p>
+            </td>
+            <td class="col-2 delete-btn">
+              <!-- btns -->
+              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">주문 상세</button>
+              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">주문 취소</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+
+
+
+  </div>
+
+  <div th:replace="fragments/footer::footer"></div>
+
+</body>
+</html>

--- a/src/main/resources/templates/order/order_history_list.html
+++ b/src/main/resources/templates/order/order_history_list.html
@@ -20,8 +20,52 @@
 
       window.addEventListener('DOMContentLoaded', function(){
 
+        document.querySelectorAll('.btn-cancel-order').forEach(
+
+          function(item) {
+
+            item.addEventListener('click', function() {
+              console.log('클릭확인');
+              let ordersId = item.value;
+              cancelOrder(ordersId);
+            });
+          }
+
+        );
 
       }); //window.addEventListener
+
+      function cancelOrder(ordersId) {
+
+          if (!confirm("선택하신 주문을 취소하시겠습니까?")) {
+            return false;
+          }
+
+          let url = '/api/order/orderItem/' + ordersId;
+
+          axios.put(url).then(function(response) {
+
+            response.data = response.data || {};
+            response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+            //success
+            //reload
+            alert('선택하신 주문을 취소하였습니다.');
+            location.href = '/order/history';
+
+          }).catch(function(error) {
+
+            if (error.response) {
+              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(익셉션 핸들러 코드 400.)
+              console.log(error.response.data);
+              alert(error.response.data.errorMessage);
+            }
+
+            console.log(error);
+          });
+
+
+      }
 
     </script>
   </th:block>
@@ -142,7 +186,7 @@
             <td class="col-2 delete-btn">
               <!-- btns -->
               <a th:href="@{/order/history/detail/{ordersId}(ordersId = ${ordersHistory.ordersId})}" class="btn btn-outline-info btn-block">주문 상세</a>
-              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">
+              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block btn-cancel-order">
                 주문 취소
               </button>
             </td>

--- a/src/main/resources/templates/order/order_history_list.html
+++ b/src/main/resources/templates/order/order_history_list.html
@@ -141,8 +141,10 @@
             </td>
             <td class="col-2 delete-btn">
               <!-- btns -->
-              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">주문 상세</button>
-              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">주문 취소</button>
+              <a th:href="@{/order/history/detail/{ordersId}(ordersId = ${ordersHistory.ordersId})}" class="btn btn-outline-info btn-block">주문 상세</a>
+              <button type="button" th:value="${ordersHistory.ordersId}" class="btn btn-outline-info btn-block">
+                주문 취소
+              </button>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
:white_check_mark: Changes

- 고객이 주문 후, 본인 주문 내역 및 주문 상세 내역을 조회할 수 있게 하였습니다.
- 고객이 주문 내역 리스트에서 주문 취소(주문 접수 상태만 가능)를 할 수 있도록 하였습니다.

<br>

:heavy_plus_sign: Related Details

- 고객의 주문 내역 조회, 주문 상세 내역은 myBatis를 통한 table join 쿼리 작성하여 구현했습니다. 
![주문상세및취소](https://user-images.githubusercontent.com/65488155/212865305-6b32a600-3249-4f57-8326-e04dadc585ef.jpg)
버튼을 이용해서 주문 상세 내역을 조회하거나, 아니면 해당 주문을 취소 상태로 변경하게끔 했습니다.
![상세주문내역](https://user-images.githubusercontent.com/65488155/212865507-11e6009b-dc60-48be-a736-bbf41a688601.jpg)

<br>

:pray: To Reviewers
- 남은 기능인 상품 상세 목록에서 낱개로 상품 주문하기(장바구니 data 상관없이 주문) 외에 해야 할 todo는 구현한 기능들에 대해서... 서버에서 요청 값에 대한 예외처리를 추가하는 것입니다. @Valid와 @ControllerAdvice 조합을 사용하여 스프링에서 클라이언트에서 받아온 값에 대해 예외처리를 실행합니다.
[참고링크]
https://cchoimin.tistory.com/entry/Valid-%EC%99%80-ControllerAdvice%EB%A1%9C-DTO-%EC%98%88%EC%99%B8%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0
- 스프링 시큐리티 때문인지 웹 컨피그 설정을 추가로 해야하는 것이 있는지 .. 로그인 시에 엉뚱한 asset 을 보여주는 버그가 있어서 이것도 수정 예정입니다.