### PR TITLE
주문 및 주문취소 시 상품재고, 상품 상태 변경 가능하도록 수정

### DIFF
--- a/src/main/java/com/shoptest/catmart/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/shoptest/catmart/configuration/SecurityConfiguration.java
@@ -29,9 +29,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
   @Override
   public void configure(WebSecurity web) throws Exception {
-    //로그인 후, static 리소스 파일을 필터링에서 제외하기
-    web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
-    
+
+    web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations()); ////로그인 후, static 리소스 파일을 필터링에서 제외하기
     super.configure(web);
   }
 
@@ -41,8 +40,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     http.csrf().disable();
 
     http.authorizeRequests().antMatchers(
-        "/main"
+        "/css/**" //css 및 기본 asset 파일은 로그인 여부와 상관없이 이 경로에 접근 허용하도록 추가한다.
+        , "/asset/**"
+        , "/"
         , "/member/join"
+        , "/product/**"
     ).permitAll();
 
     http.authorizeRequests().antMatchers("/admin/**")

--- a/src/main/java/com/shoptest/catmart/main/MainController.java
+++ b/src/main/java/com/shoptest/catmart/main/MainController.java
@@ -22,6 +22,14 @@ public class MainController {
   }
 
 
+  @RequestMapping("/")
+  public String beforLoginIndex(Model model) {
+
+    model.addAttribute("frontCategoryList", categoryService.selectFrontCategoryList());
+    return "index";
+  }
+
+
 
 
 }

--- a/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/ApiOrderController.java
@@ -1,6 +1,7 @@
 package com.shoptest.catmart.order.controller;
 
 import com.shoptest.catmart.common.model.ResponseResult;
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
 import com.shoptest.catmart.order.service.OrderService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,6 +27,16 @@ public class ApiOrderController {
 
     String email = principal.getName();
     orderService.createOrder(email);
+
+    ResponseResult responseResult = new ResponseResult(true);
+    return ResponseEntity.ok().body(responseResult);
+  }
+
+  @PostMapping("/api/order/singleProduct")
+  public ResponseEntity<?> createOrderFromProductDetail(Model model, Principal principal, @RequestBody OrderItemAddInputDto orderItemAddInputDto) {
+
+    String email = principal.getName();
+    orderService.createOrder(orderItemAddInputDto, email);
 
     ResponseResult responseResult = new ResponseResult(true);
     return ResponseEntity.ok().body(responseResult);

--- a/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
+++ b/src/main/java/com/shoptest/catmart/order/controller/OrderController.java
@@ -2,14 +2,20 @@ package com.shoptest.catmart.order.controller;
 
 import com.shoptest.catmart.cart.service.CartService;
 import com.shoptest.catmart.member.service.MemberService;
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
 import com.shoptest.catmart.order.service.OrderService;
+import com.shoptest.catmart.product.domain.ProductItem;
+import com.shoptest.catmart.product.service.ProductService;
+import java.net.http.HttpRequest;
 import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/order")
@@ -19,7 +25,9 @@ public class OrderController {
   private final CartService cartService;
   private final MemberService memberService;
   private final OrderService orderService;
+  private final ProductService productService;
 
+  /* 장바구니 -> 주문서 페이지 */
   @GetMapping("/cartItem")
   public String orderFromCart(Model model, Principal principal) {
 
@@ -28,6 +36,22 @@ public class OrderController {
     model.addAttribute("cartItemList", cartService.selectCartItemDetailList(email)); //장바구니에 담은 상품 목록
 
     return "/order/order_from_cart";
+  }
+
+  @GetMapping("/product")
+  public String orderFromProduct(
+      Model model, Principal principal, OrderItemAddInputDto orderItemAddInputDto) {
+
+    String email = null;
+    if (principal != null) {
+      email = principal.getName();
+    }
+
+    model.addAttribute("email", email);
+    model.addAttribute("shippingAddress", memberService.selectMemberAddress(email)); //배송지 (원래는 배송 관련 내용만 따로 담은 table 필요..)
+    model.addAttribute("toBeOrderItem", productService.selectOrderItemDetailByProduct(orderItemAddInputDto));
+
+    return "/order/order_from_product";
   }
 
   @GetMapping("/history")

--- a/src/main/java/com/shoptest/catmart/order/domain/Orders.java
+++ b/src/main/java/com/shoptest/catmart/order/domain/Orders.java
@@ -4,6 +4,7 @@ import com.shoptest.catmart.cart.dto.CartItemDetailDto;
 import com.shoptest.catmart.common.exception.OrderException;
 import com.shoptest.catmart.common.exception.type.OrderErrorCode;
 import com.shoptest.catmart.member.domain.Member;
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
 import com.shoptest.catmart.order.type.OrderStatus;
 import com.shoptest.catmart.product.domain.ProductItem;
 import java.time.LocalDateTime;
@@ -67,7 +68,7 @@ public class Orders {
   /* 수정일자 */
   private LocalDateTime modifiedAt;
 
-  /* 주문_상품 생성하기 */
+  /* 주문_상품 생성하기 - 장바구니에서 접근 */
   public OrdersItem createOrdersItem(ProductItem productItem, CartItemDetailDto toBeOrderItems) {
 
     OrdersItem ordersItem = OrdersItem.builder()
@@ -75,6 +76,19 @@ public class Orders {
         .quantity(toBeOrderItems.getQuantity())
         .productItem(productItem)
         .orderPrice(productItem.getPrice() * toBeOrderItems.getQuantity())
+        .createdAt(LocalDateTime.now())
+        .build();
+    return ordersItem;
+  }
+
+  /* 주문_상품 생성하기 - 단일 상품 바로 주문하기에서 접근 */
+  public OrdersItem createOrdersItem(ProductItem productItem, OrderItemAddInputDto orderItemAddInputDto) {
+
+    OrdersItem ordersItem = OrdersItem.builder()
+        .orders(this)
+        .quantity(orderItemAddInputDto.getQuantity())
+        .productItem(productItem)
+        .orderPrice(productItem.getPrice() * orderItemAddInputDto.getQuantity())
         .createdAt(LocalDateTime.now())
         .build();
     return ordersItem;

--- a/src/main/java/com/shoptest/catmart/order/dto/OrderItemAddInputDto.java
+++ b/src/main/java/com/shoptest/catmart/order/dto/OrderItemAddInputDto.java
@@ -1,0 +1,19 @@
+package com.shoptest.catmart.order.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * front 상품 상세 - 단일 상품 주문용 DTO
+ * */
+@Getter
+@Setter
+public class OrderItemAddInputDto {
+
+  /* 상품 Id */
+  private Long productItemId;
+
+  /* 장바구니_상품 개수 */
+  private int quantity;
+
+}

--- a/src/main/java/com/shoptest/catmart/order/dto/OrderItemByProductDto.java
+++ b/src/main/java/com/shoptest/catmart/order/dto/OrderItemByProductDto.java
@@ -1,0 +1,41 @@
+package com.shoptest.catmart.order.dto;
+
+import com.shoptest.catmart.product.type.ItemStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * front 주문서 상품 정보 조회 - 상품 상세보기를 통한 바로 주문하기 시 주문서 내 주문상품 조회용 DTO
+ * */
+@Getter
+@Setter
+public class OrderItemByProductDto {
+
+  /* 구매희망 상품개수 */
+  private int quantity;
+
+  /* 상품 ID */
+  private Long productItemId;
+
+  /* 상품이름 */
+  private String itemName;
+
+  /* 상품가격 */
+  private int price;
+
+  /* 상품 상태 - (판매중, 품절) */
+  private ItemStatus itemStatus;
+
+  /* 상품내용 */
+  private String itemSubject;
+
+  /* 상품재고 */
+  private int stock;
+
+  /* 상품 게시 여부 */
+  private boolean postYn;
+
+  private String urlImgPath;
+
+
+}

--- a/src/main/java/com/shoptest/catmart/order/service/OrderService.java
+++ b/src/main/java/com/shoptest/catmart/order/service/OrderService.java
@@ -1,13 +1,17 @@
 package com.shoptest.catmart.order.service;
 
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
 import com.shoptest.catmart.order.dto.OrdersHistoryDetailDto;
 import com.shoptest.catmart.order.dto.OrdersHistoryDto;
 import java.util.List;
 
 public interface OrderService {
 
-  /* 고객 - 주문하기(장바구니에서 접근) */
+  /* 고객 - 주문하기(장바구니 - 장바구니 내 모든 상픔 주문) */
   void createOrder(String email);
+
+  /* 고객 - 주문하기 (상품 상세 페이지 - 단일 상품 주문) */
+  void createOrder(OrderItemAddInputDto orderItemAddInputDto, String email);
 
   /* 고객 - 주문하기 목록 조회 */
   List<OrdersHistoryDto> selectOrdersHistoryList(String email);

--- a/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
+++ b/src/main/java/com/shoptest/catmart/product/controller/FrontProductController.java
@@ -5,6 +5,7 @@ import com.shoptest.catmart.admin.service.CategoryService;
 import com.shoptest.catmart.product.dto.FrontProductDetailDto;
 import com.shoptest.catmart.product.dto.FrontProductDto;
 import com.shoptest.catmart.product.service.ProductService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -36,7 +37,12 @@ public class FrontProductController {
   }
 
   @GetMapping("/detail/{productItemId}")
-  public String frontProductDetail(Model model, @PathVariable("productItemId") Long productItemId) {
+  public String frontProductDetail(Model model, @PathVariable("productItemId") Long productItemId, Principal principal) {
+
+    String email = null;
+    if (principal != null) {
+      email = principal.getName();
+    }
 
     FrontProductDetailDto detail = new FrontProductDetailDto();
     if (productItemId != null) {
@@ -44,6 +50,7 @@ public class FrontProductController {
     }
 
     model.addAttribute("detail", detail);
+    model.addAttribute("email", email);
     return "/product/front_product_detail";
   }
 

--- a/src/main/java/com/shoptest/catmart/product/domain/ProductItem.java
+++ b/src/main/java/com/shoptest/catmart/product/domain/ProductItem.java
@@ -70,5 +70,17 @@ public class ProductItem {
     productItem.setStock(newStock);
     return productItem;
   }
-  
+
+  /* 주문 취소 시, 주문했던 수량만큼 상품 재고 더하기 */
+  public ProductItem addStock(ProductItem productItem, int quantity) {
+
+    int newStock = productItem.getStock() + quantity;
+    if (newStock > 0) {
+      productItem.setItemStatus(ItemStatus.SAIL);
+    }
+
+    productItem.setStock(newStock);
+    return productItem;
+  }
+
 }

--- a/src/main/java/com/shoptest/catmart/product/domain/ProductItem.java
+++ b/src/main/java/com/shoptest/catmart/product/domain/ProductItem.java
@@ -58,5 +58,17 @@ public class ProductItem {
   
   /* 수정일자 */
   private LocalDateTime modifiedAt;
+
+  /* 주문 시, 주문수량만큼 상품 재고 차감하기 */
+  public ProductItem deductionStock(ProductItem productItem, int quantity) {
+
+    int newStock = productItem.getStock() - quantity;
+    if (newStock <= 0) {
+      productItem.setItemStatus(ItemStatus.OUT_OF_STOCK);
+    }
+
+    productItem.setStock(newStock);
+    return productItem;
+  }
   
 }

--- a/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
+++ b/src/main/java/com/shoptest/catmart/product/mapper/ProductMapper.java
@@ -1,5 +1,7 @@
 package com.shoptest.catmart.product.mapper;
 
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
+import com.shoptest.catmart.order.dto.OrderItemByProductDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
 import com.shoptest.catmart.product.dto.FrontProductDetailDto;
@@ -22,4 +24,6 @@ public interface ProductMapper {
   /* front - 상품 상세 조회 */
   FrontProductDetailDto frontProductDetail(long productItemId);
 
+  /* front - 주문서 내 상품 조회 (상품 상세보기 내 바로보기 진입 시 필요 조회 data) */
+  OrderItemByProductDto orderItemByProductDetail(OrderItemAddInputDto orderItemAddInputDto);
 }

--- a/src/main/java/com/shoptest/catmart/product/service/ProductService.java
+++ b/src/main/java/com/shoptest/catmart/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package com.shoptest.catmart.product.service;
 
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
+import com.shoptest.catmart.order.dto.OrderItemByProductDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
 import com.shoptest.catmart.product.dto.FrontProductDetailDto;
@@ -24,5 +26,8 @@ public interface ProductService {
 
   /* front - 상품상세 조회 */
   FrontProductDetailDto selectFrontProductDetail(Long productItemId);
+
+  /* front - 주문서(상품 상세보기 내 바로보기 진입 시 필요 조회 data) */
+  OrderItemByProductDto selectOrderItemDetailByProduct(OrderItemAddInputDto orderItemAddInputDto);
 
 }

--- a/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/shoptest/catmart/product/service/impl/ProductServiceImpl.java
@@ -1,5 +1,9 @@
 package com.shoptest.catmart.product.service.impl;
 
+import com.shoptest.catmart.common.exception.OrderException;
+import com.shoptest.catmart.common.exception.type.OrderErrorCode;
+import com.shoptest.catmart.order.dto.OrderItemAddInputDto;
+import com.shoptest.catmart.order.dto.OrderItemByProductDto;
 import com.shoptest.catmart.product.domain.ProductItem;
 import com.shoptest.catmart.product.dto.AdminProductMngDetailDto;
 import com.shoptest.catmart.product.dto.AdminProductMngDto;
@@ -68,4 +72,13 @@ public class ProductServiceImpl implements ProductService {
   public FrontProductDetailDto selectFrontProductDetail(Long productItemId) {
     return productMapper.frontProductDetail(productItemId);
   }
+
+  @Override
+  public OrderItemByProductDto selectOrderItemDetailByProduct(OrderItemAddInputDto orderItemAddInputDto) {
+
+    OrderItemByProductDto orderItemByProductDto = productMapper.orderItemByProductDetail(orderItemAddInputDto);
+    orderItemByProductDto.setQuantity(orderItemAddInputDto.getQuantity()); //주문 희망 수량으로 재세팅
+    return orderItemByProductDto;
+  }
+
 }

--- a/src/main/resources/mybatis/product/ProductMapper.xml
+++ b/src/main/resources/mybatis/product/ProductMapper.xml
@@ -72,4 +72,19 @@
     AND A.PRODUCT_ITEM_ID = #{productItemId}
   </select>
 
+  <select id="orderItemByProductDetail" resultType="com.shoptest.catmart.order.dto.OrderItemByProductDto">
+    SELECT
+      A.PRODUCT_ITEM_ID
+      , A.ITEM_NAME
+      , A.PRICE
+      , A.ITEM_STATUS
+      , A.STOCK
+      , A.POST_YN
+      , B.URL_IMG_PATH
+    FROM PRODUCT_ITEM A
+    INNER JOIN ITEM_IMG B
+    ON A.PRODUCT_ITEM_ID = B.PRODUCT_ITEM_ID
+    AND A.PRODUCT_ITEM_ID = #{productItemId}
+  </select>
+
 </mapper>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -16,7 +16,6 @@
 
         <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
           <div class="navbar-nav">
-            <a class="nav-link active" aria-current="page" href="/main">Main</a>
             <a class="nav-link" href="/product/list">전체 상품</a>
             <a sec:authorize="isAuthenticated()" class="nav-link" href="/order/history">내 주문내역</a>
             <a sec:authorize="isAuthenticated()" class="nav-link" href="/cart/list">장바구니</a>

--- a/src/main/resources/templates/order/order_from_product.html
+++ b/src/main/resources/templates/order/order_from_product.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Title</title>
+
+  <!-- CSS -->
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+
+  <!-- jQuery -->
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+  <!-- axios cdn -->
+  <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+
+  <th:block layout:fragment="script">
+    <script th:inline="javascript">
+
+      window.addEventListener('DOMContentLoaded', function() {
+
+        //금액 setting
+        init();
+
+        //결제하기 버튼 클릭 이벤트
+        document.querySelector('#btn-order').addEventListener('click', function() {
+          //주문 생성 api call
+          callOrderCreateApi();
+        });
+
+
+      }); //window.addEventListener
+
+      //화면 로딩 시, 필요한 금액 정보 setting
+      async function init() {
+
+        let totalPrice = await calculateEachProduct(); //1. 총 금액 계산하기
+        await markTotalPrice(totalPrice); //2. 계산한 총 금액 바탕으로 배송비 더한 값 ui 출력
+      }
+
+      //각 상품마다의 개수 * 금액 계산
+      function calculateEachProduct() {
+
+        return new Promise(function(resolve, reject) {
+
+          let totalPrice = 0; //총 결제금액
+
+          document.querySelectorAll('.quantity').forEach(
+
+            function(item) {
+
+              let quantity = item.querySelector('span').innerHTML; //수량
+              let eachPrice = item.parentNode.nextElementSibling.querySelector('input[type=hidden]').value; //각각 1개 가격
+              let productPrice = quantity * eachPrice; //각 상품의 수량 곱한 가격
+
+              item.parentNode.nextElementSibling.querySelector('span').innerHTML = productPrice + '원';
+              totalPrice += productPrice;
+            }
+          );
+
+          resolve(totalPrice);
+        });
+
+      }
+
+      //각 상품의 금액 합한 총 주문 금액 계산
+      function markTotalPrice(totalPrice) {
+
+        return new Promise(function(resolve, reject) {
+
+          //배송비
+          let shippingFee = (totalPrice > 30000) ? 0 : 3000;
+
+          //최종 상품 금액 표시
+          document.querySelector('#total-product-price').innerHTML = totalPrice + '원';
+          document.querySelector('#shipping-fee').innerHTML = shippingFee;
+          document.querySelector('#total-payment').innerHTML = totalPrice + shippingFee;
+
+          resolve();
+        });
+      }
+
+      //주문 생성 api 호출
+      function callOrderCreateApi() {
+
+        //login 여부 check
+        if (!isLoginUser()) {
+          return false;
+        }
+
+        let url = '/api/order/singleProduct';
+        let quantity = document.querySelector('#quantity').value;
+        let productItemId = document.querySelector('#productItemId').value;
+
+        let parameter = {
+          productItemId: productItemId
+          , quantity: quantity
+        };
+
+        axios.post(url, parameter).then(function(response) {
+
+          response.data = response.data || {};
+          response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+          //success
+          alert('해당 상품을 주문하였습니다.');
+
+        }).catch(function(error) {
+
+          if (error.response) {
+            //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.( 익셉션 핸들러 코드 400.)
+            console.log(error.response.data);
+            alert(error.response.data.errorMessage);
+          }
+
+          console.log(error);
+        });
+
+      }
+
+      function isLoginUser() {
+
+        let email = document.querySelector('#user-email').value;
+        if (isValueEmpty(email)) {
+          alert('서비스 이용을 위해 로그인해주세요.');
+          return false;
+        }
+        return true;
+      }
+
+      function isValueEmpty(value) {
+
+        if( value == "" || value == null || value == undefined || ( value != null && typeof value == "object" && !Object.keys(value).length ) ){
+
+          return true;
+        } else {
+
+          return false;
+        }
+      }
+
+    </script>
+  </th:block>
+
+  <th:block layout:fragment="css">
+    <style>
+
+      html {
+        position: relative;
+        min-height: 100%;
+        margin: 0;
+      }
+
+      body {
+        min-height: 100%;
+      }
+
+      .footer {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        padding: 15px 0;
+        text-align: center;
+      }
+
+      .header {
+        margin-bottom: 20px;
+
+      }
+
+      .content {
+        margin-bottom: 100px;
+        margin-top: 50px;
+        margin-left: 150px;
+        margin-right: 150px;
+      }
+
+      #sum-info-tab {
+        margin-top: 18px;
+      }
+
+      .order-info {
+        margin-bottom: 13px;
+      }
+
+
+    </style>
+  </th:block>
+
+</head>
+<body>
+
+  <div th:replace="fragments/header::header"></div>
+
+  <div class="content">
+
+    <!-- category info bar -->
+    <nav aria-label="breadcrumb">
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item active" aria-current="page">
+          장바구니 > <span class="badge badge-primary">주문결제</span> > 결제완료
+        </li>
+      </ol>
+    </nav>
+
+    <!-- product detail area -->
+    <div class="container"> <!-- container-md-->
+
+      <!-- shipping-info -->
+      <table class="table table-borderless" style="margin-bottom: 20px;">
+        <thead>
+        <tr>
+          <th colspan="3">
+            <span class="btn btn-primary">배송정보</span>
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th>받는 사람</th>
+            <td th:text="${shippingAddress.name}"></td>
+          </tr>
+          <tr>
+            <th>휴대전화</th>
+            <td th:text="${shippingAddress.phoneNumber}"></td>
+          </tr>
+          <tr>
+            <th>배송주소</th>
+            <td>
+              <span th:text="${shippingAddress.address}"></span> <span th:text="${shippingAddress.addressDetail}"></span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- 주문예정상품 - 장바구니 목록 -> 주문결제 page -->
+      <table class="table table-borderless order-info" id="cart-item-list" style="margin-bottom: 20px;"> <!-- container-md -->
+        <thead class="thead-light">
+          <tr>
+            <th colspan="3">
+              주문상품
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="cart-item">
+            <td class="col-7">
+              <!-- img -->
+              <div class="border-0 card mb-3" style="max-width: 300px;">
+                <div class="row no-gutters">
+                  <div class="col-md-4">
+                    <img th:src="${toBeOrderItem.urlImgPath}" class="card-img" alt="...">
+                  </div>
+                  <div class="col-md-8">
+                    <div class="card-body">
+                      <h5 th:text="${toBeOrderItem.itemName}" class="card-title"></h5>
+                      <p class="card-text">
+                        <small class="text-muted"><span th:text="${toBeOrderItem.itemStatus}" class="badge badge-pill badge-success"></span></small>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </td>
+            <td class="col-2">
+              <!-- quantity  -->
+              <div class="form-group quantity">
+                <h5>
+                  수량 <span th:text="${toBeOrderItem.quantity}"></span> 개
+                </h5>
+                <input type="hidden" th:value="${toBeOrderItem.productItemId}" id="productItemId" /> <!-- 상품 Key value -->
+                <input type="hidden" th:value="${toBeOrderItem.quantity}" id="quantity" />
+                <input type="hidden" th:value="${email}" id="user-email" />
+              </div>
+            </td>
+            <td class="col-3">
+              <!-- price -->
+              <div>
+                <h2 class="price">
+                  <span th:text="${toBeOrderItem.price}" class="badge badge-pill badge-light"></span>
+                  <input type="hidden" th:value="${toBeOrderItem.price}">
+                </h2>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <!-- amount of payment -->
+      <table class="table table-borderless order-info" style="margin-bottom: 20px;">
+        <thead class="thead-light">
+        <tr>
+          <th colspan="3">
+            최종 결제금액
+          </th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+          <th>총 상품 금액</th>
+          <td id="total-product-price"></td>
+        </tr>
+        <tr>
+          <th>배송비</th>
+          <td>+<span id="shipping-fee"></span>원</td>
+        </tr>
+        <tr>
+          <th>총 결제금액</th>
+          <td><h3><span class="badge badge-pill badge-warning" id="total-payment"></span>원</h3></td>
+        </tr>
+        </tbody>
+      </table>
+
+    </div>
+
+
+    <!-- 구매하기 영역 -->
+    <hr/>
+    <div class="d-flex justify-content-center" id="sum-info-tab">
+      <div class="container-md">
+        <div class="d-flex justify-content-center row alert alert-light">
+          <span>위 주문 내용을 확인하였으며 결제하겠습니다.</span>
+        </div>
+        <div class="row">
+          <button type="button" class="btn btn-info btn-block" id="btn-order">결제하기</button>
+        </div>
+      </div>
+    </div>
+
+
+
+  </div>
+
+  <div th:replace="fragments/footer::footer"></div>
+
+</body>
+</html>

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -25,6 +25,7 @@
         quantityInput.oninput = calculatePayment;
 
         const cartAddBtn = document.getElementById('cartAddBtn');
+        const orderNowBtn = document.getElementById('orderNowBtn');
 
         //수량에 따른 결제 금액 계산
         function calculatePayment() {
@@ -45,6 +46,7 @@
             return false;
           }
 
+          //login 여부 check
           if (!isLoginUser()) {
             return false;
           }
@@ -76,6 +78,48 @@
             console.log(error);
           });
 
+
+        });
+
+        //단일 상품 주문하기 버튼 클릭
+        orderNowBtn.addEventListener('click', function() {
+
+          const orderNowMsg = '이 상품만 바로 주문하시겠습니까?';
+          if (!confirm(orderNowMsg)) {
+            return false;
+          }
+
+          //login 여부 check
+          if (!isLoginUser()) {
+            return false;
+          }
+
+          let url = '/api/order/singleProduct';
+          let quantity = quantityInput.value;
+
+          let parameter = {
+            productItemId: productItemId
+            , quantity: quantity
+          };
+
+          axios.post(url, parameter).then(function(response) {
+
+            response.data = response.data || {};
+            response.data.responseResultHeader = response.data.responseResultHeader || {};
+
+            //success
+            alert('해당 상품을 주문하였습니다.');
+
+          }).catch(function(error) {
+
+            if (error.response) {
+              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
+              console.log(error.response.data);
+              alert(error.response.data.errorMessage);
+            }
+
+            console.log(error);
+          });
 
         });
 

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -94,32 +94,8 @@
             return false;
           }
 
-          let url = '/api/order/singleProduct';
           let quantity = quantityInput.value;
-
-          let parameter = {
-            productItemId: productItemId
-            , quantity: quantity
-          };
-
-          axios.post(url, parameter).then(function(response) {
-
-            response.data = response.data || {};
-            response.data.responseResultHeader = response.data.responseResultHeader || {};
-
-            //success
-            alert('해당 상품을 주문하였습니다.');
-
-          }).catch(function(error) {
-
-            if (error.response) {
-              //요청 후, 서버가 2xx 범위 벗어나는 상태 코드를 주었다.(장바구니 익셉션 핸들러 코드 400.)
-              console.log(error.response.data);
-              alert(error.response.data.errorMessage);
-            }
-
-            console.log(error);
-          });
+          window.location.href = "/order/product?productItemId=" + productItemId + "&quantity=" + quantity; //주문하기 폼(단일 상품 주문 시의 페이지)으로 이동
 
         });
 
@@ -147,7 +123,7 @@
 
           return false;
         }
-      };
+      }
 
     </script>
   </th:block>

--- a/src/main/resources/templates/product/front_product_detail.html
+++ b/src/main/resources/templates/product/front_product_detail.html
@@ -45,6 +45,10 @@
             return false;
           }
 
+          if (!isLoginUser()) {
+            return false;
+          }
+
           let url = '/api/cart/cartItem';
           let quantity = quantityInput.value;
 
@@ -78,6 +82,28 @@
 
 
       }); //window.addEventListener
+
+
+      function isLoginUser() {
+
+        let email = document.querySelector('#user-email').value;
+        if (isValueEmpty(email)) {
+          alert('서비스 이용을 위해 로그인해주세요.');
+          return false;
+        }
+        return true;
+      }
+
+      function isValueEmpty(value) {
+
+        if( value == "" || value == null || value == undefined || ( value != null && typeof value == "object" && !Object.keys(value).length ) ){
+
+          return true;
+        } else {
+
+          return false;
+        }
+      };
 
     </script>
   </th:block>
@@ -174,6 +200,7 @@
               <hr/>
               <p class="card-text">
                 <button class="btn btn-light btn-lg btn-block" id="cartAddBtn" type="submit">장바구니 담기</button>
+                <input type="hidden" th:value="${email}" id="user-email">
               </p>
               <p class="card-text">
                 <button class="btn btn-primary btn-lg btn-block" id="orderNowBtn" type="submit">바로 주문하기</button>


### PR DESCRIPTION
:white_check_mark: Changes

- 요구사항 재확인 후, 주문 & 주문취소 시 상품재고, 상품 상태 변경 가능하도록 수정하였습니다.
- 상품 재고량이 0이 되면 상품 등록값 기본상태인 SAIL 이 OUT_OF_STOCK로 변경되게 했습니다.
- 상품 재고량이 0인 상품에 대해 주문 취소가 일어나면 OUT_OF_STOCK이 SAIL 로 변경되게 했습니다.
- 기존에 있던 로그인 후 일어나는 엉뚱한 페이지 로딩은 스프링 시큐리티 설정에서 정적 자원 접근을 로그인하지 않았을 때에도
허용하도록 하여 해당 현상이 더 일어나지 않게 수정하였습니다.

<br>

:heavy_plus_sign: Related Details
- 주문 관련 API가 요구사항을 모두 충족시키지 않았음을 확인하고, 재고 수량 및 상품 상태 변경이 일어날 수 있게 라인을 추가했습니다.
- [주문 or 주문 취소시 상품 재고량 및 상품 상태 컬럼 확인]
![주문및주문취소data확인](https://user-images.githubusercontent.com/65488155/213182440-cce032f7-034f-4eab-901f-efb34d847769.jpg)

- 주문, 장바구니 관련 API는 javascript 로 로그인 여부 체크 라인을 추가해 로그인 유저만 api 호출을 할수 있게 1차적으로 요구사항 반영했습니다.(원칙적으로 JWT 적용 필요..)
<br>

:pray: To Reviewers
- 거의 기능 구현이 다 된 줄 알았는데, 요구사항 재확인 후, 놓친 점이 많아 다시 비즈니스적 요구사항을 충족시켰고,  API 관련해서는 JWT 적용하여 로그인 유저만 호출 가능하도록 서버 코드 추가 필요함을 체크하였습니다. (이번 기한 내 어렵다면 버전업 필요..)